### PR TITLE
Adds licensing text to generators in v2

### DIFF
--- a/packages/jh-elements/_templates/component/new/element.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.ejs.t
@@ -1,23 +1,15 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.js
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
 /**
- * Copyright 2025 Jack Henry.
- * SPDX-License-Identifier: Apache-2.0
- * * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * * http://www.apache.org/licenses/LICENSE-2.0
- * * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* SPDX-FileCopyrightText: 2025 Jack Henry
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 
 import { LitElement, css, html } from 'lit';
 

--- a/packages/jh-elements/_templates/component/new/element.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.ejs.t
@@ -1,6 +1,24 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.js
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
+/**
+ * Copyright 2025 Jack Henry.
+ * SPDX-License-Identifier: Apache-2.0
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { LitElement, css, html } from 'lit';
 
 /**

--- a/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
@@ -1,22 +1,14 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.mdx
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
 {/*
- Copyright 2025 Jack Henry.
- SPDX-License-Identifier: Apache-2.0
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
- http://www.apache.org/licenses/LICENSE-2.0
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+SPDX-FileCopyrightText: 2025 Jack Henry
+
+SPDX-License-Identifier: Apache-2.0
  */}
 import { Meta, ArgTypes } from '@storybook/blocks';
 import * as stories from './<%= unprefixedName %>.stories.js';

--- a/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
@@ -1,7 +1,23 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.mdx
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
-
+{/*
+ Copyright 2025 Jack Henry.
+ SPDX-License-Identifier: Apache-2.0
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+ http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+ */}
 import { Meta, ArgTypes } from '@storybook/blocks';
 import * as stories from './<%= unprefixedName %>.stories.js';
 

--- a/packages/jh-elements/_templates/component/new/element.stories.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.stories.ejs.t
@@ -1,23 +1,15 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.stories.js
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
 /**
- * Copyright 2025 Jack Henry.
- * SPDX-License-Identifier: Apache-2.0
- * * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * * http://www.apache.org/licenses/LICENSE-2.0
- * * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* SPDX-FileCopyrightText: 2025 Jack Henry
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 
 import { html, css } from 'lit';
 import './<%= unprefixedName %>.js';

--- a/packages/jh-elements/_templates/component/new/element.stories.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.stories.ejs.t
@@ -1,6 +1,24 @@
 ---
 to: components/<%= unprefixedName %>/<%= unprefixedName %>.stories.js
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
+/**
+ * Copyright 2025 Jack Henry.
+ * SPDX-License-Identifier: Apache-2.0
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 import { html, css } from 'lit';
 import './<%= unprefixedName %>.js';
 

--- a/packages/jh-elements/_templates/component/new/index.d-declare.ejs.t
+++ b/packages/jh-elements/_templates/component/new/index.d-declare.ejs.t
@@ -3,9 +3,9 @@ to: index.d.ts
 inject: true
 before: '^  \}\n\}'
 skip_if: "'<%= elementName %>': <%= className %>"
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
     '<%= elementName %>': <%= className %>;

--- a/packages/jh-elements/_templates/component/new/index.d-declare.ejs.t
+++ b/packages/jh-elements/_templates/component/new/index.d-declare.ejs.t
@@ -3,5 +3,9 @@ to: index.d.ts
 inject: true
 before: '^  \}\n\}'
 skip_if: "'<%= elementName %>': <%= className %>"
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
     '<%= elementName %>': <%= className %>;

--- a/packages/jh-elements/_templates/component/new/index.d-import.ejs.t
+++ b/packages/jh-elements/_templates/component/new/index.d-import.ejs.t
@@ -3,5 +3,9 @@ to: index.d.ts
 inject: true
 before: '\ndeclare global'
 skip_if: 'import \{ <%= className %>'
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
 import { <%= className %> } from './components/<%= unprefixedName %>/<%= unprefixedName %>.js';

--- a/packages/jh-elements/_templates/component/new/index.d-import.ejs.t
+++ b/packages/jh-elements/_templates/component/new/index.d-import.ejs.t
@@ -3,9 +3,9 @@ to: index.d.ts
 inject: true
 before: '\ndeclare global'
 skip_if: 'import \{ <%= className %>'
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
 import { <%= className %> } from './components/<%= unprefixedName %>/<%= unprefixedName %>.js';

--- a/packages/jh-elements/index.d.ts
+++ b/packages/jh-elements/index.d.ts
@@ -28,7 +28,6 @@ import { JhTable } from './components/table/table.js';
 import { JhTableRow } from './components/table-row/table-row.js';
 import { JhTableDataCell } from './components/table-data-cell/table-data-cell.js';
 import { JhTableHeaderCell } from './components/table-header-cell/table-header-cell.js';
-import { JhTest } from './components/test/test.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -62,6 +61,5 @@ declare global {
     'jh-table-row': JhTableRow;
     'jh-table-data-cell': JhTableDataCell;
     'jh-table-header-cell': JhTableHeaderCell;
-    'jh-test': JhTest;
   }
 }

--- a/packages/jh-elements/index.d.ts
+++ b/packages/jh-elements/index.d.ts
@@ -28,6 +28,7 @@ import { JhTable } from './components/table/table.js';
 import { JhTableRow } from './components/table-row/table-row.js';
 import { JhTableDataCell } from './components/table-data-cell/table-data-cell.js';
 import { JhTableHeaderCell } from './components/table-header-cell/table-header-cell.js';
+import { JhTest } from './components/test/test.js';
 
 declare global {
   interface HTMLElementTagNameMap {
@@ -61,5 +62,6 @@ declare global {
     'jh-table-row': JhTableRow;
     'jh-table-data-cell': JhTableDataCell;
     'jh-table-header-cell': JhTableHeaderCell;
+    'jh-test': JhTest;
   }
 }

--- a/packages/jh-icons/_templates/icon/new/icon.ejs.t
+++ b/packages/jh-icons/_templates/icon/new/icon.ejs.t
@@ -1,24 +1,16 @@
 ---
 to: <%= outputPath %>/icon-<%= name %>.js
 force: true
+#
+# SPDX-FileCopyrightText: 2025 Jack Henry
 # 
-# Copyright 2025 Jack Henry.
 # SPDX-License-Identifier: Apache-2.0
-# See LICENSE file in project root for full terms.
 ---
 /**
- * Copyright 2025 Jack Henry.
- * SPDX-License-Identifier: Apache-2.0
- * * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- * * http://www.apache.org/licenses/LICENSE-2.0
- * * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+* SPDX-FileCopyrightText: 2025 Jack Henry
+*
+* SPDX-License-Identifier: Apache-2.0
+*/
 import {LitElement, css, html} from 'lit';
 
 export default class <%= h.inflection.classify(prefix.replace(/-/gi,'_')) %>Icon<%= h.inflection.classify(name.replace(/-/gi,'_')) %> extends LitElement {

--- a/packages/jh-icons/_templates/icon/new/icon.ejs.t
+++ b/packages/jh-icons/_templates/icon/new/icon.ejs.t
@@ -1,7 +1,24 @@
 ---
 to: <%= outputPath %>/icon-<%= name %>.js
 force: true
+# 
+# Copyright 2025 Jack Henry.
+# SPDX-License-Identifier: Apache-2.0
+# See LICENSE file in project root for full terms.
 ---
+/**
+ * Copyright 2025 Jack Henry.
+ * SPDX-License-Identifier: Apache-2.0
+ * * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ * * http://www.apache.org/licenses/LICENSE-2.0
+ * * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import {LitElement, css, html} from 'lit';
 
 export default class <%= h.inflection.classify(prefix.replace(/-/gi,'_')) %>Icon<%= h.inflection.classify(name.replace(/-/gi,'_')) %> extends LitElement {

--- a/packages/jh-tokens/lib/build.js
+++ b/packages/jh-tokens/lib/build.js
@@ -14,17 +14,9 @@ function getStyleDictionary(theme, platform) {
     hooks: {
       fileHeaders: { 
         licensedFileHeader: (defaultMessages = []) => [ //license info gets added to css and js files
-          'Copyright 2025 Jack Henry.',
+          'SPDX-FileCopyrightText: 2025 Jack Henry',
+          '',
           'SPDX-License-Identifier: Apache-2.0',
-          'Licensed under the Apache License, Version 2.0 (the "License");',
-          'you may not use this file except in compliance with the License.',
-          'You may obtain a copy of the License at',
-          'http://www.apache.org/licenses/LICENSE-2.0',
-          'Unless required by applicable law or agreed to in writing, software',
-          'distributed under the License is distributed on an "AS IS" BASIS,',
-          'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
-          'See the License for the specific language governing permissions and',
-          'limitations under the License.',
           '',
           ...defaultMessages,
           `Generated on ${new Date().toUTCString()}`,

--- a/packages/jh-tokens/lib/build.js
+++ b/packages/jh-tokens/lib/build.js
@@ -12,8 +12,20 @@ function getStyleDictionary(theme, platform) {
       `tokens/alias/**/*.json`
     ],
     hooks: {
-      fileHeaders: {
-        defaultFileHeader: (defaultMessages = []) => [
+      fileHeaders: { 
+        licensedFileHeader: (defaultMessages = []) => [ //license info gets added to css and js files
+          'Copyright 2025 Jack Henry.',
+          'SPDX-License-Identifier: Apache-2.0',
+          'Licensed under the Apache License, Version 2.0 (the "License");',
+          'you may not use this file except in compliance with the License.',
+          'You may obtain a copy of the License at',
+          'http://www.apache.org/licenses/LICENSE-2.0',
+          'Unless required by applicable law or agreed to in writing, software',
+          'distributed under the License is distributed on an "AS IS" BASIS,',
+          'WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.',
+          'See the License for the specific language governing permissions and',
+          'limitations under the License.',
+          '',
           ...defaultMessages,
           `Generated on ${new Date().toUTCString()}`,
         ],
@@ -40,7 +52,7 @@ function getStyleDictionary(theme, platform) {
             options: {
               // if file should keep output references: ie --color-danger: var(--color-red); vs --color-danger: #ff0000;
               outputReferences: true,
-              fileHeader: 'defaultFileHeader',
+              fileHeader: 'licensedFileHeader',
               selector: `${theme === 'light' ? ':root' : `.jh-theme-${theme}`}`,
             },
           },
@@ -50,7 +62,7 @@ function getStyleDictionary(theme, platform) {
             options: {
               outputReferences: true,
               usesDtcg: true,
-              fileHeader: 'defaultFileHeader',
+              fileHeader: 'licensedFileHeader',
               selector: `${theme === 'light' ? ':root' : `.jh-theme-${theme}`}`,
             },
           },

--- a/packages/jh-tokens/platforms/web/css/jh-theme-dark.css
+++ b/packages/jh-tokens/platforms/web/css/jh-theme-dark.css
@@ -1,6 +1,10 @@
 /**
+ * SPDX-FileCopyrightText: 2025 Jack Henry
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Fri, 03 Oct 2025 14:49:50 GMT
+ * Generated on Wed, 12 Nov 2025 19:24:22 GMT
  */
 
 .jh-theme-dark {

--- a/packages/jh-tokens/platforms/web/css/jh-theme-light.css
+++ b/packages/jh-tokens/platforms/web/css/jh-theme-light.css
@@ -1,6 +1,10 @@
 /**
+ * SPDX-FileCopyrightText: 2025 Jack Henry
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Fri, 03 Oct 2025 14:49:50 GMT
+ * Generated on Wed, 12 Nov 2025 19:24:22 GMT
  */
 
 :root {

--- a/packages/jh-tokens/platforms/web/esm/jh-theme-dark.js
+++ b/packages/jh-tokens/platforms/web/esm/jh-theme-dark.js
@@ -1,6 +1,10 @@
 /**
+ * SPDX-FileCopyrightText: 2025 Jack Henry
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Fri, 03 Oct 2025 14:49:50 GMT
+ * Generated on Wed, 12 Nov 2025 19:24:22 GMT
  */
 
 export default `

--- a/packages/jh-tokens/platforms/web/esm/jh-theme-light.js
+++ b/packages/jh-tokens/platforms/web/esm/jh-theme-light.js
@@ -1,6 +1,10 @@
 /**
+ * SPDX-FileCopyrightText: 2025 Jack Henry
+ * 
+ * SPDX-License-Identifier: Apache-2.0
+ * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Fri, 03 Oct 2025 14:49:50 GMT
+ * Generated on Wed, 12 Nov 2025 19:24:22 GMT
  */
 
 export default `


### PR DESCRIPTION
## What It Does

- It adds the licensing text to the generators in `jh-icons` and `jh-elements`. 
- It adds the licensing text to the Style Dictionary build script in `jh-tokens` for `css` and `js` outputs.
- It manually adds a concise licensing text to the generator files themselves `ejs.t` files in their yaml front matter. This was tricky to do with the general script, so I did it here.

(With Style Dictionary V4 the code is much more streamlined, and there is no need for an extra `file-header.js` file).

## How To Test

- Run `pnpm generate:jh-elements test` to generate a new component `jh-test`.
- Run `pnpm build:jh-icons` to generate the wc-icons set.
- Run `pnpm build:jh-tokens` to generate the token files (css and js).

Check that the licensing information is present and in the correct format in each output.

## Notes/Caveats

Build the `jh-tokens` files before merging so the tokens files contain the license and the most recent generation date.
The icons can either run through the base script or be re-generated through this. 

## Resources

N/A

## Dependencies

N/A
