### PR TITLE
Bumped jh-elements and jh-tokens package versions

### DIFF
--- a/packages/jh-elements/package.json
+++ b/packages/jh-elements/package.json
@@ -30,7 +30,7 @@
     "postpack": "rm -f NOTICE"
   },
   "dependencies": {
-    "@jack-henry/jh-tokens": "workspace:2.0.0-beta.7",
+    "@jack-henry/jh-tokens": "workspace:2.0.0-beta.8",
     "@jack-henry/jh-icons": "workspace:2.0.0-beta.6",
     "lit": "3.3.1"
   },

--- a/packages/jh-elements/package.json
+++ b/packages/jh-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jack-henry/jh-elements",
   "description": "Jack Henry's design system web components.",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Banno/jack-henry-design-system.git"

--- a/packages/jh-tokens/package.json
+++ b/packages/jh-tokens/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jack-henry/jh-tokens",
   "description": "Jack Henry design system core design tokens.",
-  "version": "2.0.0-beta.7",
+  "version": "2.0.0-beta.8",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Banno/jack-henry-design-system.git"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Increments package versions for jh-elements and jh-tokens for release.

## How To Test

- Run `yarn storybook` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Verify presence of new features

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
