### PR TITLE
Adds onboarding documentation to v1

### DIFF
--- a/packages/jh-ui/docs/about-jh/about.mdx
+++ b/packages/jh-ui/docs/about-jh/about.mdx
@@ -87,3 +87,9 @@ All components are tested in the latest 2 versions of Chrome, Firefox, and Safar
     </tr>
   </tbody>
 </table>
+
+## Licensing
+
+Our design system, including all components, design tokens, and source code, is licensed under the **Apache License, Version 2.0**. This project adheres to the REUSE specification, with license information declared using the `SPDX-License-Identifier: Apache-2.0` tag in each source file.
+
+Please see the complete [license file](https://github.com/Banno/jack-henry-design-system/blob/main/LICENSE) for full legal details.

--- a/packages/jh-ui/docs/about-jh/releases.mdx
+++ b/packages/jh-ui/docs/about-jh/releases.mdx
@@ -4,7 +4,7 @@ import { Meta } from '@storybook/blocks';
 
 # Releases
 
-The Jack Henry Design System maintains a regular release cycle. All Design System assets from both design and engineering, with the exception of some documentation, are versioned together. This means that with each release, changes to Figma UI kits, design tokens, component code, and documentation are all aligned with the same release number and published simultaneously. 
+The Jack Henry Design System maintains a regular release cycle where design and engineering assets are released in coordination. While major versions are synchronized across design and code, minor updates, such as Figma UI kit updates or component code changes, may be released independently.
 
 All releases adhere to [Semantic Versioning principles](https://semver.org/), using a three-part version number: **MAJOR.MINOR.PATCH**. 
 

--- a/packages/jh-ui/docs/about-jh/releases.mdx
+++ b/packages/jh-ui/docs/about-jh/releases.mdx
@@ -1,0 +1,43 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Welcome/Releases" tags={['new']} />
+
+# Releases
+
+The Jack Henry Design System maintains a regular release cycle. All Design System assets from both design and engineering, with the exception of some documentation, are versioned together. This means that with each release, changes to Figma UI kits, design tokens, component code, and documentation are all aligned with the same release number and published simultaneously. 
+
+All releases adhere to [Semantic Versioning principles](https://semver.org/), using a three-part version number: **MAJOR.MINOR.PATCH**. 
+
+This system ensures our consumers can expect the scope and impact of any update. 
+
+<table>
+  <thead>
+    <tr>
+      <th>Version</th>
+      <th>Impact</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>PATCH</td>
+      <td>Includes bug fixes that do **not** result in breaking changes.</td>
+    </tr>
+    <tr>
+      <td>MINOR</td>
+      <td>Includes added functionality and/or changes that do **not** result in breaking changes.</td>
+    </tr>
+    <tr>
+      <td>MAJOR</td>
+      <td>Includes larger sets of breaking changes and more complex updates. **Requires** review and potential code changes to upgrade.</td>
+    </tr>
+  </tbody>
+</table>
+
+We recommend reviewing the accompanying [changelog](https://github.com/Banno/jack-henry-design-system/releases) with every update to ensure a predictable update process for your application. 
+
+Please review our [release guide](https://github.com/Banno/jack-henry-design-system/blob/main/README.md#release-guide) for more information on our release cadence, types, and phases. 
+
+### Resources
+
+- [Changelog](https://github.com/Banno/jack-henry-design-system/releases)
+- [Release Guide](https://github.com/Banno/jack-henry-design-system/blob/main/README.md#release-guide)

--- a/packages/jh-ui/docs/getting-started/design-tokens.mdx
+++ b/packages/jh-ui/docs/getting-started/design-tokens.mdx
@@ -1,0 +1,99 @@
+import { Meta } from '@storybook/blocks';
+
+<Meta title="Getting Started/Design Tokens" tags={['new']} />
+
+# Design Tokens
+
+Design tokens are fundamental to the Jack Henry Design System and serve as the single source of truth for our visual design attributes. They are named entities that store specific values, such as colors, typography, and spacing, in a platform-agnostic format.
+
+Design tokens ensure:
+
+- **Consistency:** Tokens ensure that every application component, whether on web, mobile, or in design files, references the same defined style.
+- **Maintainability:** Changing a single token value (i.e., updating the primary brand color) instantly updates every component that consumes that token across the entire system.
+- **Scalability:** They enable the easy creation of themes (like light/dark modes) by simply mapping a token to a new underlying value. 
+
+## Using Design Tokens and Styling Hooks
+
+Our design tokens are built with specific structures in mind that allow them to be incorporated and extended in a consistent and predictable manner.
+
+Design tokens provide two methods for styling: **Alias Tokens** for large-scale theming and **Styling Hooks** for granular, component-specific adjustments. Both are applied using CSS Custom Properties, which leverage the cascading nature of CSS to allow for fine-grained style control at various levels of your application's DOM structure.
+
+### Application-Level Overrides
+
+To apply a style change across your entire application, you should override our alias tokens at the highest possible scope, typically on the `:root` pseudo-class, or the `<html>` or `<body>` tag.
+
+For example, to change the value of `--jh-color-content-brand-enabled` throughout the entire application, you would override the token:
+
+```css
+body {
+ --jh-color-content-brand-enabled: rgb(120, 179, 245);
+}
+```
+
+### Component-Level Styling Hooks
+
+To apply style changes to specific components, you should define the supplied component tokens aka styling hooks. 
+
+The exposed styling hooks are listed under the CSS custom properties section in each component's API documentation. Each entry includes:
+
+* **Property Name:** the name of the styling hook (i.e., `--jh-badge-color-background-enabled`).
+* **Default Value:** the value that is implemented if no styling hook value is supplied (i.e., `--jh-color-content-brand-enabled`).
+* **Description:** the element and CSS property the styling hook applies to (i.e., the badge's background color).
+
+To override a component's style, you'll need to apply the corresponding styling hook to the component instance:
+
+```css
+jh-badge {
+  --jh-badge-color-background-enabled: green;
+}
+```
+
+#### Styling Hooks for Slotted Content
+
+Slotted content resides in the Light DOM, meaning its styles are not encapsulated by the component's Shadow DOM. This allows it to be targeted and styled using basic CSS selectors, just like standard HTML elements.
+
+The example below shows how to directly style an element placed in the component's default slot using standard CSS:
+
+```javascript
+p {
+ color: blue;
+}
+
+<jh-card>
+  <p>Card default body slot</p>
+</jh-card>
+
+```
+
+Some components expose specific styling hooks for slotted content for user convenience. While you can use direct CSS (as shown above), using the provided styling hooks is the preferred API for consistent and maintenance-friendly styling.
+
+To assign a styling hook to slotted content, apply the styling hook to the component instance itself. The component's internal CSS will then use that styling hook's value to style the slotted element.
+
+```javascript
+jh-card {
+  --jh-card-header-color-text: red;
+  --jh-card-footer-color-text: blue;
+}
+
+<jh-card>
+  <h2 slot="jh-card-header">Card Header Slot</h2>
+  <p>Card body slot. Lorem ipsum dolor sit amet.</p>
+  <footer slot="jh-card-footer">Card footer slot</footer>
+</jh-card>
+```
+
+## Accessibility and Styling Overrides
+
+While our styling hooks offer flexibility, applying custom overrides introduces the risk of violating accessibility standards. When modifying colors, typography, or spacing, you assume the responsibility for ensuring the resulting component meets the necessary criteria.
+
+Key Accessibility Checks for Custom Overrides:
+
+**Text Contrast:** When overriding colors, such as background or text color, verify the color contrast ratio meets the [WCAG 1.4.3 Contrast(Minimum) Criterion](https://www.w3.org/WAI/WCAG22/Understanding/contrast-minimum.html). 
+
+**Focus States:** Ensure that any custom styles applied to interactive components (like buttons or inputs) do not remove or obscure the default focus indicator that appears when a user navigates via keyboard.
+
+**Spacing and Layout:** Be cautious when overriding spacing tokens. Excessive crowding or improper alignment can negatively impact readability and the predictable flow of content for users relying on screen magnification.
+
+## Resources 
+
+Explore our [Design Tokens documentation](https://jackhenry.design/pages/foundations/design-tokens/overview/) for a deeper dive into design tokens and the Jack Henry Design System.

--- a/packages/jh-ui/docs/getting-started/usage.mdx
+++ b/packages/jh-ui/docs/getting-started/usage.mdx
@@ -155,8 +155,35 @@ property has an integer value of 24. Review each component doc to better underst
 
 ### Slots
 
-Slots are one of the features that are part of the web component technology suite. Their purpose is to provide content to a component.
-Our components include two types of slots; default and named slots.
+Slots are a core feature of the web component technology suite, and allows authors to inject their own content into a component. Slotted content remains in the Light DOM, which means it is not encapsulated by the component's Shadow DOM. This behavior provides two key benefits:
+
+1. **Flexibility:** You can pass in any valid HTML content into a slot. 
+2. **Custom Styling:** Since the slotted content remains in the light DOM, it is accessible to external CSS selectors. This enables you to apply your own classes, CSS custom properties, or direct styling to the slotted elements. 
+
+#### Default
+
+Many components include a default slot option that will accept any HTML an author provides. To use a default slot, simply declare your HTML between the component tags:
+
+```html
+<jh-list-item>
+  <div class="container">
+    <div>My list content</div>
+  </div>
+</jh-list-item>
+```
+
+#### Named
+
+Some components will include named slots. Named slots target specific regions of a component to render your HTML. Multiple named slots
+can be present along with a default slot in some cases. To target a slot, include the slot attribute with the targeted slot name:
+
+```html
+<jh-list-item>
+  <div slot="jh-list-item-content" class="container">
+    <div>My list content</div>
+  </div>
+</jh-list-item>
+```
 
 #### Default
 

--- a/packages/jh-ui/docs/getting-started/usage.mdx
+++ b/packages/jh-ui/docs/getting-started/usage.mdx
@@ -67,7 +67,7 @@ jh-badge {
 }
 ```
 
-For more information on working with styling hooks, please reference the [design tokens documentation](/docs/getting-started-tokens--docs). 
+For more information on working with styling hooks, please reference the [design tokens documentation](/docs/getting-started-design-tokens--docs). 
 
 ## Using fonts
 

--- a/packages/jh-ui/docs/getting-started/usage.mdx
+++ b/packages/jh-ui/docs/getting-started/usage.mdx
@@ -49,6 +49,26 @@ This will place both light and dark themed design system CSS custom properties a
 
 Additionally, you can provide specific custom property overrides by appending your own style tag to the document head *below* the design system themes. This ensures that as the stylesheets cascade, your custom property will successfully override that defined by the design system. 
 
+## Using styling hooks
+
+Because our components encapsulate their styles in the Shadow DOM, direct external CSS often won't reach internal elements. Some components expose specific CSS Custom Properties (aka styling hooks) that act as "hooks" for you to adjust their appearance. 
+
+The exposed styling hooks are listed under the CSS custom properties section in the component's API documentation. Each entry includes:
+
+* **Property Name:** the name of the styling hook (i.e., `--jh-badge-color-background-enabled`).
+* **Default Value:** the value that is implemented if no styling hook value is supplied (i.e., `--jh-color-content-brand-enabled`).
+* **Description:** the element and CSS property the styling hook applies to (i.e., the badge's background color).
+
+To override a component's style, you'll need to apply the corresponding styling hook to the component instance:
+
+```css
+jh-badge {
+  --jh-badge-color-background-enabled: green;
+}
+```
+
+For more information on working with styling hooks, please reference the [design tokens documentation](/docs/getting-started-tokens--docs). 
+
 ## Using fonts
 
 The Roboto Flex variable font is our primary font. We strongly encourage self-hosting fonts rather than relying on google fonts' CDN. 


### PR DESCRIPTION
## What It Does

Adds additional documentation to improve onboarding process. New docs include:
- Design Tokens page.
- Releases page. 
- Licensing information under the about page. 
- Additional information on Design Tokens and Slots under the usage page. 

## How To Test

- Run `pnpm storybook:jh-ui` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Review the added documentation. 

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A