### PR TITLE
Update links to .design for v2

### DIFF
--- a/packages/jh-elements/components/badge/badge.mdx
+++ b/packages/jh-elements/components/badge/badge.mdx
@@ -11,7 +11,7 @@ import * as stories from './badge.stories.js';
 
 # Badge
 
-[Guidelines](https://jackhenry.design/pages/components/badge/)
+[Guidelines](https://jackhenry.design/v2/components/badge/)
 
 <hr />
 

--- a/packages/jh-elements/components/button/button.mdx
+++ b/packages/jh-elements/components/button/button.mdx
@@ -11,7 +11,7 @@ import * as stories from './button.stories.js';
 
 # Button
 
-[Guidelines](https://jackhenry.design/pages/components/button/)
+[Guidelines](https://jackhenry.design/v2/components/button/)
 
 <hr />
 

--- a/packages/jh-elements/components/card/card.mdx
+++ b/packages/jh-elements/components/card/card.mdx
@@ -11,7 +11,7 @@ import * as stories from './card.stories.js';
 
 # Card
 
-[Guidelines](https://jackhenry.design/pages/components/card/)
+[Guidelines](https://jackhenry.design/v2/components/card/)
 
 <hr />
 

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.mdx
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.mdx
@@ -11,7 +11,7 @@ import * as stories from './checkbox-group.stories.js';
 
 # Checkbox Group
 
-[Guidelines](https://jackhenry.design/pages/components/checkbox-group/)
+[Guidelines](https://jackhenry.design/v2/components/checkbox-group/)
 
 <hr />
 

--- a/packages/jh-elements/components/checkbox/checkbox.mdx
+++ b/packages/jh-elements/components/checkbox/checkbox.mdx
@@ -11,7 +11,7 @@ import * as stories from './checkbox.stories.js';
 
 # Checkbox
 
-[Guidelines](https://jackhenry.design/pages/components/checkbox/)
+[Guidelines](https://jackhenry.design/v2/components/checkbox/)
 
 <hr />
 

--- a/packages/jh-elements/components/divider/divider.mdx
+++ b/packages/jh-elements/components/divider/divider.mdx
@@ -11,7 +11,7 @@ import * as stories from './divider.stories.js';
 
 # Divider
 
-[Guidelines](https://jackhenry.design/pages/components/divider/)
+[Guidelines](https://jackhenry.design/v2/components/divider/)
 
 <hr />
 

--- a/packages/jh-elements/components/icon/icon.mdx
+++ b/packages/jh-elements/components/icon/icon.mdx
@@ -11,7 +11,7 @@ import * as stories from './icon.stories.js';
 
 # Icon
 
-[Guidelines](https://jackhenry.design/pages/components/icon/)
+[Guidelines](https://jackhenry.design/v2/components/icon/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-email/input-email.mdx
+++ b/packages/jh-elements/components/input-email/input-email.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-email.stories.js';
 
 # Input Email
 
-[Guidelines](https://jackhenry.design/pages/components/input-email/)
+[Guidelines](https://jackhenry.design/v2/components/input-email/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-password/input-password.mdx
+++ b/packages/jh-elements/components/input-password/input-password.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-password.stories.js';
 
 # Input Password
 
-[Guidelines](https://jackhenry.design/pages/components/input-password/)
+[Guidelines](https://jackhenry.design/v2/components/input-password/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-search/input-search.mdx
+++ b/packages/jh-elements/components/input-search/input-search.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-search.stories.js';
 
 # Input Search
 
-[Guidelines](https://jackhenry.design/pages/components/input-search/)
+[Guidelines](https://jackhenry.design/v2/components/input-search/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-telephone/input-telephone.mdx
+++ b/packages/jh-elements/components/input-telephone/input-telephone.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-telephone.stories.js';
 
 # Input Telephone
 
-[Guidelines](https://jackhenry.design/pages/components/input-telephone/)
+[Guidelines](https://jackhenry.design/v2/components/input-telephone/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-textarea/input-textarea.mdx
+++ b/packages/jh-elements/components/input-textarea/input-textarea.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-textarea.stories.js';
 
 # Input Textarea
 
-[Guidelines](https://jackhenry.design/pages/components/input-textarea/)
+[Guidelines](https://jackhenry.design/v2/components/input-textarea/)
 
 <hr />
 

--- a/packages/jh-elements/components/input-url/input-url.mdx
+++ b/packages/jh-elements/components/input-url/input-url.mdx
@@ -11,7 +11,7 @@ import * as stories from './input-url.stories.js';
 
 # Input Url
 
-[Guidelines](https://jackhenry.design/pages/components/input-url/)
+[Guidelines](https://jackhenry.design/v2/components/input-url/)
 
 <hr />
 

--- a/packages/jh-elements/components/input/input.mdx
+++ b/packages/jh-elements/components/input/input.mdx
@@ -11,7 +11,7 @@ import * as stories from './input.stories.js';
 
 # Input
 
-[Guidelines](https://jackhenry.design/pages/components/input/)
+[Guidelines](https://jackhenry.design/v2/components/input/)
 
 <hr />
 

--- a/packages/jh-elements/components/list-group/list-group.mdx
+++ b/packages/jh-elements/components/list-group/list-group.mdx
@@ -11,7 +11,7 @@ import * as stories from './list-group.stories.js';
 
 # List Group
 
-[Guidelines](https://jackhenry.design/pages/components/list-group/)
+[Guidelines](https://jackhenry.design/v2/components/list-group/)
 
 <hr />
 

--- a/packages/jh-elements/components/list-item/list-item.mdx
+++ b/packages/jh-elements/components/list-item/list-item.mdx
@@ -11,7 +11,7 @@ import * as stories from './list-item.stories.js';
 
 # List Item
 
-[Guidelines](https://jackhenry.design/pages/components/list-item/)
+[Guidelines](https://jackhenry.design/v2/components/list-item/)
 
 <hr />
 

--- a/packages/jh-elements/components/menu/menu.mdx
+++ b/packages/jh-elements/components/menu/menu.mdx
@@ -11,7 +11,7 @@ import * as stories from './menu.stories.js';
 
 # Menu
 
-[Guidelines](https://jackhenry.design/pages/components/menu/)
+[Guidelines](https://jackhenry.design/v2/components/menu/)
 
 <hr />
 

--- a/packages/jh-elements/components/notification/notification.mdx
+++ b/packages/jh-elements/components/notification/notification.mdx
@@ -11,7 +11,7 @@ import * as stories from './notification.stories.js';
 
 # Notification
 
-[Guidelines](https://jackhenry.design/pages/components/notification/)
+[Guidelines](https://jackhenry.design/v2/components/notification/)
 
 <hr />
 

--- a/packages/jh-elements/components/progress/progress.mdx
+++ b/packages/jh-elements/components/progress/progress.mdx
@@ -11,7 +11,7 @@ import * as stories from './progress.stories.js';
 
 # Progress
 
-[Guidelines](https://jackhenry.design/pages/components/progress/)
+[Guidelines](https://jackhenry.design/v2/components/progress/)
 
 <hr />
 

--- a/packages/jh-elements/components/radio-group/radio-group.mdx
+++ b/packages/jh-elements/components/radio-group/radio-group.mdx
@@ -11,7 +11,7 @@ import * as stories from './radio-group.stories.js';
 
 # Radio Group
 
-[Guidelines](https://jackhenry.design/pages/components/radio-group/)
+[Guidelines](https://jackhenry.design/v2/components/radio-group/)
 
 <hr />
 

--- a/packages/jh-elements/components/radio/radio.mdx
+++ b/packages/jh-elements/components/radio/radio.mdx
@@ -11,7 +11,7 @@ import * as stories from './radio.stories.js';
 
 # Radio
 
-[Guidelines](https://jackhenry.design/pages/components/radio/)
+[Guidelines](https://jackhenry.design/v2/components/radio/)
 
 <hr />
 

--- a/packages/jh-elements/components/switch/switch.mdx
+++ b/packages/jh-elements/components/switch/switch.mdx
@@ -11,7 +11,7 @@ import * as stories from './switch.stories.js';
 
 # Switch
 
-[Guidelines](https://jackhenry.design/pages/components/switch/)
+[Guidelines](https://jackhenry.design/v2/components/switch/)
 
 <hr />
 

--- a/packages/jh-elements/components/table-data-cell/table-data-cell.mdx
+++ b/packages/jh-elements/components/table-data-cell/table-data-cell.mdx
@@ -11,7 +11,7 @@ import * as stories from './table-data-cell.stories.js';
 
 # Table Data Cell
 
-[Guidelines](https://jackhenry.design/pages/components/table-data-cell/)
+[Guidelines](https://jackhenry.design/v2/components/table-data-cell/)
 
 <hr />
 

--- a/packages/jh-elements/components/table-header-cell/table-header-cell.mdx
+++ b/packages/jh-elements/components/table-header-cell/table-header-cell.mdx
@@ -11,7 +11,7 @@ import * as stories from './table-header-cell.stories.js';
 
 # Table Header Cell
 
-[Guidelines](https://jackhenry.design/pages/components/table-header-cell/)
+[Guidelines](https://jackhenry.design/v2/components/table-header-cell/)
 
 <hr />
 

--- a/packages/jh-elements/components/table-row/table-row.mdx
+++ b/packages/jh-elements/components/table-row/table-row.mdx
@@ -11,7 +11,7 @@ import * as stories from './table-row.stories.js';
 
 # Table Row
 
-[Guidelines](https://jackhenry.design/pages/components/table-row/)
+[Guidelines](https://jackhenry.design/v2/components/table-row/)
 
 <hr />
 

--- a/packages/jh-elements/components/table/table.mdx
+++ b/packages/jh-elements/components/table/table.mdx
@@ -11,7 +11,7 @@ import * as stories from './table.stories.js';
 
 # Table
 
-[Guidelines](https://jackhenry.design/pages/components/table/)
+[Guidelines](https://jackhenry.design/v2/components/table/)
 
 <hr />
 

--- a/packages/jh-elements/components/tag-group/tag-group.mdx
+++ b/packages/jh-elements/components/tag-group/tag-group.mdx
@@ -11,7 +11,7 @@ import * as stories from './tag-group.stories.js';
 
 # Tag Group
 
-[Guidelines](https://jackhenry.design/pages/components/tag-group/)
+[Guidelines](https://jackhenry.design/v2/components/tag-group/)
 
 <hr />
 

--- a/packages/jh-elements/components/tag/tag.mdx
+++ b/packages/jh-elements/components/tag/tag.mdx
@@ -11,7 +11,7 @@ import * as stories from './tag.stories.js';
 
 # Tag
 
-[Guidelines](https://jackhenry.design/pages/components/tag/)
+[Guidelines](https://jackhenry.design/v2/components/tag/)
 
 <hr />
 

--- a/packages/jh-elements/components/toast-controller/toast-controller.mdx
+++ b/packages/jh-elements/components/toast-controller/toast-controller.mdx
@@ -11,7 +11,7 @@ import * as stories from './toast-controller.stories.js';
 
 # Toast Controller
 
-[Guidelines](https://jackhenry.design/pages/components/toast/)
+[Guidelines](https://jackhenry.design/v2/components/toast/)
 
 <hr />
 

--- a/packages/jh-elements/components/toast/toast.mdx
+++ b/packages/jh-elements/components/toast/toast.mdx
@@ -11,7 +11,7 @@ import * as stories from './toast.stories.js';
 
 # Toast
 
-[Guidelines](https://jackhenry.design/pages/components/toast/)
+[Guidelines](https://jackhenry.design/v2/components/toast/)
 
 <hr />
 

--- a/packages/jh-elements/components/tooltip/tooltip.mdx
+++ b/packages/jh-elements/components/tooltip/tooltip.mdx
@@ -11,7 +11,7 @@ import * as stories from './tooltip.stories.js';
 
 # Tooltip
 
-[Guidelines](https://jackhenry.design/pages/components/tooltip/)
+[Guidelines](https://jackhenry.design/v2/components/tooltip/)
 
 <hr />
 

--- a/packages/jh-elements/docs/getting-started/typography.mdx
+++ b/packages/jh-elements/docs/getting-started/typography.mdx
@@ -10,7 +10,7 @@ import { Meta } from '@storybook/blocks';
 
 # Typography
 
-The Jack Henry Design System uses the variable fonts **Roboto Flex** as its main font and **Roboto Mono** for monospace text (see [Typography](https://jackhenry.design/pages/foundations/typography/) details).
+The Jack Henry Design System uses the variable fonts **Roboto Flex** as its main font and **Roboto Mono** for monospace text (see [Typography](https://jackhenry.design/v2/foundations/typography/) details).
 We use variable fonts because they offer increased flexibility and customization, while also reducing the number of font files required to download.
 
 ## Using our fonts

--- a/packages/jh-icons/README.md
+++ b/packages/jh-icons/README.md
@@ -35,7 +35,7 @@ Please note that any files with the same filename as the output web component wi
 
 ## Icon Documentation
 
-Access documentation on our [iconography](https://jackhenry.design/pages/foundations/icons/) and [icon web component](https://jackhenry.design/pages/components/icon/).
+Access documentation on our [iconography](https://jackhenry.design/v2/foundations/icons/) and [icon web component](https://jackhenry.design/pages/components/icon/).
 
 ## Contributing
 

--- a/packages/jh-tokens/README.md
+++ b/packages/jh-tokens/README.md
@@ -8,5 +8,5 @@ SPDX-License-Identifier: Apache-2.0
 
 Contains Jack Henry's core design tokens designed to be used with our [design system elements](https://github.com/Banno/jack-henry-design-system/tree/main/packages/jh-elements) package. To get started, visit our documentation sites.
 
-* [jackhenry.design tokens](https://jackhenry.design/pages/foundations/design-tokens/overview/) provides documentation on our design tokens.
+* [jackhenry.design tokens](https://jackhenry.design/v2/foundations/design-tokens/overview/) provides documentation on our design tokens.
 * [Jackhenry.design](https://jackhenry.design) focuses on introducing the underlying concepts of the Design System, usage guidelines, and a style guide.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It updates the links to .design to point to the V2 version.

## How To Test

- Run `pnpm storybook:jh-elements` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Check the links in the Components docs pages.
- Also check link in Typography doc page and in jh-icons and jh-tokens Reamde.md(s).

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
