### PR TITLE
Removes duplicate piece in usage and update v2-release text

### DIFF
--- a/packages/jh-ui/docs/getting-started/usage.mdx
+++ b/packages/jh-ui/docs/getting-started/usage.mdx
@@ -185,32 +185,6 @@ can be present along with a default slot in some cases. To target a slot, includ
 </jh-list-item>
 ```
 
-#### Default
-
-Many components include a default slot option that will accept any HTML an author provides. To use a default slot, simply declare your
-HTML between the component tags:
-
-```html
-<jh-list-item>
-  <div class="container">
-    <div>My list content</div>
-  </div>
-</jh-list-item>
-```
-
-#### Named
-
-Some components will include named slots. Named slots target specific regions of a component to render your HTML. Multiple named slots
-can be present along with a default slot in some cases. To target a slot, include the slot attribute with the targeted slot name:
-
-```html
-<jh-list-item>
-  <div slot="jh-list-item-content" class="container">
-    <div>My list content</div>
-  </div>
-</jh-list-item>
-```
-
 ### Events
 
 You can attach listeners for global events (clicks, keyboard events, etc.) to the components as you normally would. In addition, some components will also emit their own `jh-`

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -10,7 +10,7 @@ import { Meta } from '@storybook/blocks';
 <div className="toc-ignore">
 # V2 Release
 
-**Warning!** This page is continuously changing. We may add or remove scope as needed. All v2 pages can be viewed [here](https://release-v2--68f8e6a25b256d0ef89b13e6.chromatic.com/?path=/docs/welcome-about-jh--docs)
+**Warning!** This page is continuously changing. We may add or remove scope as needed. Explore the [latest v2 Storybook instance](https://release-v2--68f8e6a25b256d0ef89b13e6.chromatic.com/?path=/docs/welcome-about-jh--docs).
 
 ## Summary
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It removes a duplicate piece of Docs from the Usage page.
And it updates the url text on the v2-release page.

## How To Test

- Run `pnpm storybook:jh-ui` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
-  Check the usage page and the v2-release page.

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
