### PR TITLE
Adds notice scripts to jh-tokens

### DIFF
--- a/packages/jh-tokens/package.json
+++ b/packages/jh-tokens/package.json
@@ -16,12 +16,15 @@
   "type": "module",
   "files": [
     "platforms",
-    "utils"
+    "utils",
+    "NOTICE"
   ],
   "scripts": {
     "build:tokens": "node ./lib/build.js",
     "merge": "node ./lib/merge.js",
-    "build": "npm run build:tokens && npm run merge"
+    "build": "npm run build:tokens && npm run merge",
+    "prepack": "cp ../../NOTICE .",
+    "postpack": "rm -f NOTICE"
   },
   "devDependencies": {
     "style-dictionary": "4.1.1"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds the scripts to add the NOTICE file to the jh-token folder.

## How To Test

- Go to jh-tokens and run `pnpm pack`.
-Check that the NOTICE file is present in the tarball using: `tar -xzOf jack-henry-jh-tokens-2.0.0-beta.8.tgz package/NOTICE`

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
