### PR TITLE
Adds internal support instructions to GitHub issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility-issue.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility-issue.yml
@@ -10,7 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for helping us improve the accessibility of the Jack Henry Design System! Please remember to search for open issues before submitting a new issue.
+        Thank you for helping us improve the accessibility of the Jack Henry Design System! Please remember to search for open and closed issues before submitting.
+
+        Jack Henry teams seeking support should report issues through our internal Slack channel.
   - type: dropdown
     id: affected-browser
     attributes:

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -10,7 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report a bug in the Jack Henry Design System! Please remember to search for open issues before submitting a new issue.
+        Thank you for taking the time to report a bug in the Jack Henry Design System! Please remember to search for open and closed issues before submitting.
+
+        Jack Henry teams seeking support should report issues through our internal Slack channel.
   - type: dropdown
     id: affected-browser
     attributes:

--- a/.github/ISSUE_TEMPLATE/design-issue.yml
+++ b/.github/ISSUE_TEMPLATE/design-issue.yml
@@ -10,9 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report a design issue regarding our web components or Figma UI Kit. 
-        
-        Please remember to search for open issues before submitting.
+        Thank you for taking the time to report a design issue regarding our web components or Figma UI Kit. Please remember to search for open and closed issues before submitting.
+
+        Jack Henry teams seeking support should report issues through our internal Slack channel.
   - type: dropdown
     id: affected-package
     attributes:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -10,9 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to report an issue or improvement regarding our design system documentation.
+        Thank you for taking the time to report an issue or improvement regarding our design system documentation. Please remember to search for open and closed issues before submitting.
 
-        Please remember to search for open issues before submitting.
+        Jack Henry teams seeking support should report issues through our internal Slack channel.
   - type: dropdown
     id: documentation-type
     attributes:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -10,7 +10,9 @@ body:
   - type: markdown
     attributes:
       value: |
-        Thank you for taking the time to suggest a new feature or component! Please remember to search for open and closed issues before submitting.
+        Thank you for suggesting a new feature or component! Please remember to search for open and closed issues before submitting.
+
+        Jack Henry teams seeking support should report issues through our internal Slack channel.
   - type: textarea
     id: feature-motivation
     attributes:


### PR DESCRIPTION
## What It Does

Adds internal support instructions to GitHub issue template.

## How To Test

- Review the issue templates under the .github directory. 

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
