### PR TITLE
Adds the Reuse Github Action

### DIFF
--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,4 +1,5 @@
 # SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V.
+#
 # SPDX-License-Identifier: CC0-1.0
 name: REUSE Compliance Check
 

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -4,6 +4,8 @@
 name: REUSE Compliance Check
 
 on: [push, pull_request]
+permissions:
+  contents: read
 
 jobs:
   reuse-linter:

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,0 +1,15 @@
+# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V.
+# SPDX-License-Identifier: CC0-1.0
+name: REUSE Compliance Check
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: REUSE Compliance Check
+        uses: fsfe/reuse-action@v6

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -1,16 +1,16 @@
-# SPDX-FileCopyrightText: 2020 Free Software Foundation Europe e.V.
+# SPDX-FileCopyrightText: 2025 Jack Henry
 #
-# SPDX-License-Identifier: CC0-1.0
+# SPDX-License-Identifier: Apache-2.0
 name: REUSE Compliance Check
 
 on: [push, pull_request]
 
 jobs:
-  test:
+  reuse-linter:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - name: REUSE Compliance Check
+      - name: REUSE lint
         uses: fsfe/reuse-action@v6

--- a/packages/jh-ui/docs/about-jh/about.mdx
+++ b/packages/jh-ui/docs/about-jh/about.mdx
@@ -89,7 +89,7 @@ All components are tested in the latest 2 versions of Chrome, Firefox, and Safar
 </table>
 
 ## Licensing
-
+{/* REUSE-IgnoreStart */}
 Our design system, including all components, design tokens, and source code, is licensed under the **Apache License, Version 2.0**. This project adheres to the REUSE specification, with license information declared using the `SPDX-License-Identifier: Apache-2.0` tag in each source file.
-
+{/* REUSE-IgnoreEnd */}
 Please see the complete [license file](https://github.com/Banno/jack-henry-design-system/blob/main/LICENSE) for full legal details.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds the Reuse Github Action on pushes and on PRs.
It also adds a Reuse Ignore comment to a line in about.mdx with licensing information which confuses the reuse linter.

## How To Test

- Check that the Reuse Compliance Check action is running correctly on pushes and PRs.

## Notes/Caveats

N/A

## Resources

[Reuse Github Action](https://github.com/marketplace/actions/reuse-compliance-check)

## Dependencies

N/A
