### PR TITLE
Adds jh-icon package changes to migration docs

### DIFF
--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -394,3 +394,22 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
 * `jh-input-field-dimension-padding-right`
 
 </div>
+
+## Migrating jh-icons
+
+The following icon has been renamed. Please update all instances in your codebase.
+
+<table>
+  <thead>
+    <tr>
+      <th>Deprecated Icon</th>
+      <th>New Icon</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>jh-icon-shield-check</td>
+      <td>jh-icon-shield-checkmark</td>
+    </tr>
+  </tbody>
+</table>

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -424,6 +424,14 @@ An enhanced HTML table component, which includes sorting hooks, and all its supc
 - `jh-table-header-cell`: the table header cell component.
 - `jh-table-data-cell`: the table data cell component.
 
+## jh-icons 
+
+V2 introduces 149 new icons to the icons library. See the [icon gallery](https://release-v2--68f8e6a25b256d0ef89b13e6.chromatic.com/?path=/docs/iconography-gallery--gallery) to explore the full, updated collection.
+
+### Deprecated Icon:
+
+- The `jh-icon-shield-check` icon has been replaced by the `jh-icon-shield-checkmark` icon. 
+
 ## Developer experience
 
 DX was a major focus of this release and we introduce a number of enhancements and new packages to help authors quickly build high quality applications.


### PR DESCRIPTION
## What It Does

Adds the following changes to the what's new docs:
- addition of 149 new icons 
- renaming of `jh-icon-shield-check` icon to `jh-icon-shield-checkmark`.

## How To Test

- Run `pnpm storybook:jh-ui` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Review migration docs

## Notes/Caveats

N/A

## Resources

N/A
## Dependencies

N/A
