### PR TITLE
Corrects GitHub Issues Templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/accessibility-issue.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility-issue.yml
@@ -37,7 +37,7 @@ body:
       label: Package Version
       description: Which version of the Jack Henry Design System are you using? e.g., v1.14.0
     validations:
-        required: true
+      required: true
   - type: input
     id: assistive-technology
     attributes:

--- a/.github/ISSUE_TEMPLATE/accessibility-issue.yml
+++ b/.github/ISSUE_TEMPLATE/accessibility-issue.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Accessibility Issue
-about: Report an accessibility issue in the Jack Henry Design System.
+description: Report an accessibility issue in the Jack Henry Design System.
 title: '[a11y]: '
 labels: 'type: a11y'
 body:
@@ -36,7 +36,7 @@ body:
     attributes:
       label: Package Version
       description: Which version of the Jack Henry Design System are you using? e.g., v1.14.0
-      validations:
+    validations:
         required: true
   - type: input
     id: assistive-technology

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Bug Report
-about: Report something that is not working as expected.
+description: Report something that is not working as expected.
 title: '[Bug]: '
 labels: 'type: bug, status: needs triage'
 body:

--- a/.github/ISSUE_TEMPLATE/design-issue.yml
+++ b/.github/ISSUE_TEMPLATE/design-issue.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Design Issue
-about: Report a design issue
+description: Report a design issue
 title: '[Design Issue]: '
 labels: 'status: needs triage, type: figma design kit'
 body:

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Documentation
-about: Have an issue with our documentation or a suggestion for improvement?
+description: Have an issue with our documentation or a suggestion for improvement?
 title: '[Documentation]: '
 labels: 'type: docs'
 body:

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -3,7 +3,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 name: Feature Request
-about: Have an idea for a new feature or component? Submit it here.
+description: Have an idea for a new feature or component? Submit it here.
 title: '[Feature Request]: '
 labels: 'proposal: open, type: feature request'
 body:
@@ -36,8 +36,8 @@ body:
         - '@jack-henry/jh-elements (formerly jh-ui)' 
         - '@jack-henry/jh-tokens (formerly jh-core)'
         - '@jack-henry/jh-icons'
-      validations:
-        required: true
+    validations:
+      required: true
   - type: dropdown
     id: business-priority
     attributes:
@@ -47,5 +47,5 @@ body:
         - Low
         - Medium
         - High
-      validations:
-        required: true
+    validations:
+      required: true

--- a/.github/ISSUE_TEMPLATE/feature-request.yml
+++ b/.github/ISSUE_TEMPLATE/feature-request.yml
@@ -12,7 +12,7 @@ body:
       value: |
         Thank you for suggesting a new feature or component! Please remember to search for open and closed issues before submitting.
 
-        Jack Henry teams seeking support should report issues through our internal Slack channel.
+        Jack Henry teams should submit feature requests through our internal Slack channel.
   - type: textarea
     id: feature-motivation
     attributes:


### PR DESCRIPTION
## What It Does

Corrects the GitHub issues templates by implementing the following changes:
1. Replaces the `about` key with `description`. 
2. Corrects the indentation of the `validations` key. 

## How To Test

- Review the issue template files under the `.github` directory. 

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
