### PR TITLE
[Input Password] Clear button positioning fix, input padding fix, and code cleanup

### DIFF
--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -29,6 +29,9 @@ export class JhInputPassword extends JhInput {
         .display-clear-button input {
           padding-right: var(--jh-dimension-2400);
         }
+        input {
+          padding-right: var(--jh-dimension-1400);
+        }
         :host([size='small']) .password-toggle-btn {
           top: 4px;
         }

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -21,7 +21,7 @@ export class JhInputPassword extends JhInput {
       css`
         .password-toggle-btn {
           position: absolute;
-          right: var(--jh-input-field-dimension-padding-right, var(--jh-dimension-400));
+          right: var(--jh-dimension-400);
         }
         :host([size='small']) .password-toggle-btn {
           top: 4px;

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -76,9 +76,8 @@ export class JhInputPassword extends JhInput {
     this.#inputEl = this.shadowRoot.querySelector('input');
   }
 
-  async updated(changedProperties) {
-    // await super.updated so that addInputClass method runs after the base input is updated
-    await super.updated(changedProperties);
+  updated(changedProperties) {
+    super.updated(changedProperties);
 
     if (changedProperties.has('passwordVisible')) {
       if (this.passwordVisible) {
@@ -88,14 +87,6 @@ export class JhInputPassword extends JhInput {
       }
     }
     this.#insertTogglePasswordBtn();
-    this.#addInputClass();
-  }
-
-  #addInputClass() {
-    // hook into base input styles to add padding to input to accommodate the toggle password button
-    if (!this.#inputEl.classList.contains('input-right-slot-button')) {
-      this.#inputEl.classList.add('input-right-slot-button');
-    }
   }
 
   #insertTogglePasswordBtn() {

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -23,6 +23,12 @@ export class JhInputPassword extends JhInput {
           position: absolute;
           right: var(--jh-dimension-400);
         }
+        .clear-button {
+          right: var(--jh-dimension-1400);
+        }
+        .display-clear-button input {
+          padding-right: var(--jh-dimension-2400);
+        }
         :host([size='small']) .password-toggle-btn {
           top: 4px;
         }

--- a/packages/jh-elements/components/input-password/input-password.stories.js
+++ b/packages/jh-elements/components/input-password/input-password.stories.js
@@ -6,6 +6,7 @@ import { html, css } from 'lit';
 import './input-password.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '@jack-henry/jh-icons/icons-wc/icon-id-card.js';
+import '@jack-henry/jh-icons/icons-wc/icon-magnifying-glass.js';
 
 const disableControls = {
   'password-visible': { control: { disable: true } },
@@ -256,5 +257,15 @@ export const Default = { render: (args) => html`
 `};
 
 Default.argTypes = {
+  ...disableControls,
+};
+
+export const Slots = { render: (args) => html`
+  <jh-input-password
+    label="Label"
+    helper-text="Helper text"
+    show-clear-button><jh-icon-magnifying-glass slot="jh-input-left"></jh-icon-magnifying-glass></jh-input-password>`};
+
+Slots.argTypes = {
   ...disableControls,
 };

--- a/packages/jh-elements/components/input-password/input-password.stories.js
+++ b/packages/jh-elements/components/input-password/input-password.stories.js
@@ -6,7 +6,6 @@ import { html, css } from 'lit';
 import './input-password.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '@jack-henry/jh-icons/icons-wc/icon-id-card.js';
-import '@jack-henry/jh-icons/icons-wc/icon-magnifying-glass.js';
 
 const disableControls = {
   'password-visible': { control: { disable: true } },
@@ -257,15 +256,5 @@ export const Default = { render: (args) => html`
 `};
 
 Default.argTypes = {
-  ...disableControls,
-};
-
-export const Slots = { render: (args) => html`
-  <jh-input-password
-    label="Label"
-    helper-text="Helper text"
-    show-clear-button><jh-icon-magnifying-glass slot="jh-input-left"></jh-icon-magnifying-glass></jh-input-password>`};
-
-Slots.argTypes = {
   ...disableControls,
 };


### PR DESCRIPTION
## What It Does

Corrects the positioning of the clear button. Corrects the padding of the input field when the clear button is not present. Removes dead code, including: the deprecated input styling hook `--jh-input-field-dimension-padding-right` and the addInputClass method (not needed since the clear button isn't located in the right slot). 

## How To Test

- Run `pnpm storybook:jh-elements` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Review the input-password component Slots story and ensure the clear button positioning is correct. 
- Review the default story and ensure the input field padding is correct when text is entered into the field. 

## Notes/Caveats

The Slots story will be removed before merging. 

## Resources

N/A

## Dependencies

N/A
