### PR TITLE
[Input Search] Adds jh-input:clear-button-click to the storybook actions

### DIFF
--- a/packages/jh-elements/components/input-search/input-search.stories.js
+++ b/packages/jh-elements/components/input-search/input-search.stories.js
@@ -45,7 +45,7 @@ export default {
   tags: ['beta'],
   parameters: {
     actions: {
-      handles: ['jh-input-search:clear-search-button-click', 'jh-change', 'jh-select', 'jh-input', 'jh-maxlength'],
+      handles: ['jh-input:clear-button-click', 'jh-change', 'jh-select', 'jh-input', 'jh-maxlength'],
     },
   },
   argTypes: {


### PR DESCRIPTION
## What It Does

Adds jh-input:clear-button-click to the input-search component storybook actions.

## How To Test

- Run `pnpm storybook:jh-elements` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Enter text into the input field and clear the value using the clear button. Check that the event was captured under the storybook actions tab. 

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
