### PR TITLE
[Input password] Reflects the password-visible attribute

### DIFF
--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -48,7 +48,7 @@ export class JhInputPassword extends JhInput {
   static get properties() {
     return {
       /** Unmasks the input field value when set. */
-      passwordVisible: { type: Boolean, attribute: 'password-visible'},
+      passwordVisible: { type: Boolean, attribute: 'password-visible', reflect: true},
       /** Sets an `aria-label` on the toggle password button, which encapsulates the `jh-input-password-visible` slot, to assist screen reader users. The label should indicate that activating the button will mask the password. */
       accessibleLabelHidePassword: {
         type: String,


### PR DESCRIPTION
## What It Does

Updates the `password-visible` property definition to include `reflect: true`. Ensures that the component's internal state for password visibility is reflected as a corresponding attribute in the DOM. 

## How To Test

- Run `pnpm storybook:jh-elements` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Toggle the `password-visible` button and ensure that the attribute is correctly reflected in the DOM. 

## Notes/Caveats

N/A
## Resources

N/A
## Dependencies

N/A
