### PR TITLE
Upgraded v2 storybook version

### DIFF
--- a/packages/jh-elements/package.json
+++ b/packages/jh-elements/package.json
@@ -45,7 +45,7 @@
     "@storybook/web-components-vite": "8.4.6",
     "chromatic": "5.8.3",
     "hygen": "6.2.11",
-    "storybook": "8.4.6",
+    "storybook": "8.6.15",
     "storybook-addon-tag-badges": "1.3.1",
     "storybook-dark-mode": "4.0.1",
     "web-component-analyzer": "1.1.6",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,6 @@
 # SPDX-FileCopyrightText: 2025 Jack Henry
 #
 # SPDX-License-Identifier: Apache-2.0
-
 lockfileVersion: '6.0'
 
 importers:
@@ -29,28 +28,28 @@ importers:
     devDependencies:
       '@storybook/addon-a11y':
         specifier: 8.4.6
-        version: 8.4.6(storybook@8.4.6)
+        version: 8.4.6(storybook@8.6.15)
       '@storybook/addon-actions':
         specifier: 8.4.6
-        version: 8.4.6(storybook@8.4.6)
+        version: 8.4.6(storybook@8.6.15)
       '@storybook/addon-essentials':
         specifier: 8.4.6
-        version: 8.4.6(@types/react@18.2.37)(storybook@8.4.6)
+        version: 8.4.6(@types/react@18.2.37)(storybook@8.6.15)
       '@storybook/blocks':
         specifier: 8.4.6
-        version: 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6)
+        version: 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15)
       '@storybook/manager-api':
         specifier: 8.4.6
-        version: 8.4.6(storybook@8.4.6)
+        version: 8.4.6(storybook@8.6.15)
       '@storybook/theming':
         specifier: 8.4.6
-        version: 8.4.6(storybook@8.4.6)
+        version: 8.4.6(storybook@8.6.15)
       '@storybook/web-components':
         specifier: 8.4.6
-        version: 8.4.6(lit@3.3.1)(storybook@8.4.6)
+        version: 8.4.6(lit@3.3.1)(storybook@8.6.15)
       '@storybook/web-components-vite':
         specifier: 8.4.6
-        version: 8.4.6(lit@3.3.1)(storybook@8.4.6)(vite@5.4.12)
+        version: 8.4.6(lit@3.3.1)(storybook@8.6.15)(vite@5.4.12)
       chromatic:
         specifier: 5.8.3
         version: 5.8.3
@@ -58,14 +57,14 @@ importers:
         specifier: 6.2.11
         version: 6.2.11
       storybook:
-        specifier: 8.4.6
-        version: 8.4.6
+        specifier: 8.6.15
+        version: 8.6.15
       storybook-addon-tag-badges:
         specifier: 1.3.1
-        version: 1.3.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6)
+        version: 1.3.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15)
       storybook-dark-mode:
         specifier: 4.0.1
-        version: 4.0.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6)
+        version: 4.0.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15)
       vite:
         specifier: 5.4.12
         version: 5.4.12
@@ -990,17 +989,17 @@ packages:
       - zenObservable
     dev: true
 
-  /@storybook/addon-a11y@8.4.6(storybook@8.4.6):
+  /@storybook/addon-a11y@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-Z6x/yfStplSROgmBTtiJ8LJgTqPgzW3Q7KXi+l+KoZ0pht6Nz9cYfcyygLCaftBk1ZaL7SDDIrjCP0H1NwfYiQ==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
-      '@storybook/addon-highlight': 8.4.6(storybook@8.4.6)
+      '@storybook/addon-highlight': 8.4.6(storybook@8.6.15)
       axe-core: 4.8.2
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/addon-actions@8.4.6(storybook@8.4.6):
+  /@storybook/addon-actions@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-vbplwjMj7UXbdzoFhQkqFHLQAPJX8OVGTM9Q+yjuWDHViaKKUlgRWp0jclT7aIDNJQU2a6wJbTimHgJeF16Vhg==}
     peerDependencies:
       storybook: ^8.4.6
@@ -1009,116 +1008,116 @@ packages:
       '@types/uuid': 9.0.8
       dequal: 2.0.3
       polished: 4.2.2
-      storybook: 8.4.6
+      storybook: 8.6.15
       uuid: 9.0.1
     dev: true
 
-  /@storybook/addon-backgrounds@8.4.6(storybook@8.4.6):
+  /@storybook/addon-backgrounds@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-RSjJ3iElxlQXebZrz1s5LeoLpAXr9LAGifX7w0abMzN5sg6QSwNeUHko2eT3V57M3k1Fa/5Eelso/QBQifFEog==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@storybook/global': 5.0.0
       memoizerific: 1.11.3
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-controls@8.4.6(storybook@8.4.6):
+  /@storybook/addon-controls@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-70pEGWh0C2g8s0DYsISElOzsMbQS6p/K9iU5EqfotDF+hvEqstjsV/bTbR5f3OK4vR/7Gxamk7j8RVd14Nql6A==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@storybook/global': 5.0.0
       dequal: 2.0.3
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-docs@8.4.6(@types/react@18.2.37)(storybook@8.4.6):
+  /@storybook/addon-docs@8.4.6(@types/react@18.2.37)(storybook@8.6.15):
     resolution: {integrity: sha512-olxz61W7PW/EsXrKhLrYbI3rn9GMBhY3KIOF/6tumbRkh0Siu/qe4EAImaV9NNwiC1R7+De/1OIVMY6o0EIZVw==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@mdx-js/react': 3.0.1(@types/react@18.2.37)(react@18.3.1)
-      '@storybook/blocks': 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6)
-      '@storybook/csf-plugin': 8.4.6(storybook@8.4.6)
-      '@storybook/react-dom-shim': 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6)
+      '@storybook/blocks': 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15)
+      '@storybook/csf-plugin': 8.4.6(storybook@8.6.15)
+      '@storybook/react-dom-shim': 8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15)
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-essentials@8.4.6(@types/react@18.2.37)(storybook@8.4.6):
+  /@storybook/addon-essentials@8.4.6(@types/react@18.2.37)(storybook@8.6.15):
     resolution: {integrity: sha512-TbFqyvWFUKw8LBpVcZuGQydzVB/3kSuHxDHi+Wj3Qas3cxBl7+w4/HjwomT2D2Tni1dZ1uPDOsAtNLmwp1POsg==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
-      '@storybook/addon-actions': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-backgrounds': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-controls': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-docs': 8.4.6(@types/react@18.2.37)(storybook@8.4.6)
-      '@storybook/addon-highlight': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-measure': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-outline': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-toolbars': 8.4.6(storybook@8.4.6)
-      '@storybook/addon-viewport': 8.4.6(storybook@8.4.6)
-      storybook: 8.4.6
+      '@storybook/addon-actions': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-backgrounds': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-controls': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-docs': 8.4.6(@types/react@18.2.37)(storybook@8.6.15)
+      '@storybook/addon-highlight': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-measure': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-outline': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-toolbars': 8.4.6(storybook@8.6.15)
+      '@storybook/addon-viewport': 8.4.6(storybook@8.6.15)
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
     dev: true
 
-  /@storybook/addon-highlight@8.4.6(storybook@8.4.6):
+  /@storybook/addon-highlight@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-m8wedbqDMbwkP99dNHkHAiAUkx5E7FEEEyLPX1zfkhZWOGtTkavXHH235SGp50zD75LQ6eC/BvgegrzxSQa9Wg==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/addon-measure@8.4.6(storybook@8.4.6):
+  /@storybook/addon-measure@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-N2IRpr39g5KpexCAS1vIHJT+phc9Yilwm3PULds2rQ66VMTbkxobXJDdt0NS05g5n9/eDniroNQwdCeLg4tkpw==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.6
+      storybook: 8.6.15
       tiny-invariant: 1.3.3
     dev: true
 
-  /@storybook/addon-outline@8.4.6(storybook@8.4.6):
+  /@storybook/addon-outline@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-EhcWx8OpK85HxQulLWzpWUHEwQpDYuAiKzsFj9ivAbfeljkIWNTG04mierfaH1xX016uL9RtLJL/zwBS5ChnFg==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/addon-toolbars@8.4.6(storybook@8.4.6):
+  /@storybook/addon-toolbars@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-+Xao/uGa8FnYsyUiREUkYXWNysm3Aba8tL/Bwd+HufHtdiKJGa9lrXaC7VLCqBUaEjwqM3aaPwqEWIROsthmPQ==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/addon-viewport@8.4.6(storybook@8.4.6):
+  /@storybook/addon-viewport@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-BuQll5YzOCpMS7p5Rsw9wcmi8hTnEKyg6+qAbkZNfiZ2JhXCa1GFUqX725fF1whpYVQULtkQxU8r+vahoRn7Yg==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
       memoizerific: 1.11.3
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/blocks@8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6):
+  /@storybook/blocks@8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15):
     resolution: {integrity: sha512-Gzbx8hM7ZQIHlQELcFIMbY1v+r1Po4mlinq0QVPtKS4lBcW4eZIsesbxOaL+uFNrxb583TLFzXo0DbRPzS46sg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -1134,37 +1133,37 @@ packages:
       '@storybook/icons': 1.2.12(react-dom@18.2.0)(react@18.3.1)
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/builder-vite@8.4.6(storybook@8.4.6)(vite@5.4.12):
+  /@storybook/builder-vite@8.4.6(storybook@8.6.15)(vite@5.4.12):
     resolution: {integrity: sha512-PyJsaEPyuRFFEplpNUi+nbuJd7d1DC2dAZjpsaHTXyqg5iPIbkIgsbCJLUDeIXnUDqM/utjmMpN0sQKJuhIc6w==}
     peerDependencies:
       storybook: ^8.4.6
       vite: ^4.0.0 || ^5.0.0 || ^6.0.0
     dependencies:
-      '@storybook/csf-plugin': 8.4.6(storybook@8.4.6)
+      '@storybook/csf-plugin': 8.4.6(storybook@8.6.15)
       browser-assert: 1.2.1
-      storybook: 8.4.6
+      storybook: 8.6.15
       ts-dedent: 2.2.0
       vite: 5.4.12
     dev: true
 
-  /@storybook/components@8.2.4(storybook@8.4.6):
+  /@storybook/components@8.2.4(storybook@8.6.15):
     resolution: {integrity: sha512-JLT1RoR/RXX+ZTeFoY85CRHb9Zz3l0PRRUSetEjoIJdnBGeL5C38bs0s9QnYjpCDLUlhdYhTln+GzmbyH8ocpA==}
     peerDependencies:
       storybook: ^8.2.4
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/components@8.4.6(storybook@8.4.6):
+  /@storybook/components@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-9tKSJJCyFT5RZMRGyozTBJkr9C9Yfk1nuOE9XbDEE1Z+3/IypKR9+iwc5mfNBStDNY+rxtYWNLKBb5GPR2yhzA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
   /@storybook/core-events@8.0.9:
@@ -1173,15 +1172,15 @@ packages:
       ts-dedent: 2.2.0
     dev: true
 
-  /@storybook/core@8.4.6:
-    resolution: {integrity: sha512-WeojVtHy0/t50tzw/15S+DLzKsj8BN9yWdo3vJMvm+nflLFvfq1XvD9WGOWeaFp8E/o3AP+4HprXG0r42KEJtA==}
+  /@storybook/core@8.6.15(storybook@8.6.15):
+    resolution: {integrity: sha512-VFpKcphNurJpSC4fpUfKL3GTXVoL53oytghGR30QIw5jKWwaT50HVbTyb41BLOUuZjmMhUQA8weiQEew6RX0gw==}
     peerDependencies:
       prettier: ^2 || ^3
     peerDependenciesMeta:
       prettier:
         optional: true
     dependencies:
-      '@storybook/csf': 0.1.11
+      '@storybook/theming': 8.6.15(storybook@8.6.15)
       better-opn: 3.0.2
       browser-assert: 1.2.1
       esbuild: 0.21.5
@@ -1194,16 +1193,17 @@ packages:
       ws: 8.14.2
     transitivePeerDependencies:
       - bufferutil
+      - storybook
       - supports-color
       - utf-8-validate
     dev: true
 
-  /@storybook/csf-plugin@8.4.6(storybook@8.4.6):
+  /@storybook/csf-plugin@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-JDIT0czC4yMgKGNf39KTZr3zm5MusAZdn6LBrTfvWb7CrTCR4iVHa4lp2yb7EJk41vHsBec0QUYDDuiFH/vV0g==}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
       unplugin: 1.5.0
     dev: true
 
@@ -1239,23 +1239,23 @@ packages:
       react-dom: 18.2.0(react@18.3.1)
     dev: true
 
-  /@storybook/manager-api@8.4.6(storybook@8.4.6):
+  /@storybook/manager-api@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-TsXlQ5m5rTl2KNT9icPFyy822AqXrx1QplZBt/L7cFn7SpqQKDeSta21FH7MG0piAvzOweXebVSqKngJ6cCWWQ==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/preview-api@8.4.6(storybook@8.4.6):
+  /@storybook/preview-api@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-LbD+lR1FGvWaJBXteVx5xdgs1x1D7tyidBg2CsW2ex+cP0iJ176JgjPfutZxlWOfQnhfRYNnJ3WKoCIfxFOTKA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/react-dom-shim@8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6):
+  /@storybook/react-dom-shim@8.4.6(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15):
     resolution: {integrity: sha512-f7RM8GO++fqMxbjNdEzeGS1P821jXuwRnAraejk5hyjB5SqetauFxMwoFYEYfJXPaLX2qIubnIJ78hdJ/IBaEA==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0-beta
@@ -1264,46 +1264,54 @@ packages:
     dependencies:
       react: 18.3.1
       react-dom: 18.2.0(react@18.3.1)
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/theming@8.4.6(storybook@8.4.6):
+  /@storybook/theming@8.4.6(storybook@8.6.15):
     resolution: {integrity: sha512-q7vDPN/mgj7cXIVQ9R1/V75hrzNgKkm2G0LjMo57//9/djQ+7LxvBsR1iScbFIRSEqppvMiBFzkts+2uXidySA==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
-      storybook: 8.4.6
+      storybook: 8.6.15
     dev: true
 
-  /@storybook/web-components-vite@8.4.6(lit@3.3.1)(storybook@8.4.6)(vite@5.4.12):
+  /@storybook/theming@8.6.15(storybook@8.6.15):
+    resolution: {integrity: sha512-dAbL0XOekyT6XsF49R6Etj3WxQ/LpdJDIswUUeHgVJ6/yd2opZOGbPxnwA3zlmAh1c0tvpPyhSDXxSG79u8e4Q==}
+    peerDependencies:
+      storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
+    dependencies:
+      storybook: 8.6.15
+    dev: true
+
+  /@storybook/web-components-vite@8.4.6(lit@3.3.1)(storybook@8.6.15)(vite@5.4.12):
     resolution: {integrity: sha512-OUaraqrR/hasT/laIvUndcwj1d9NLPcjULH8eh2FI8UQ80sZjz3htsFuOd3W6dxLqLVBIMMYne9mOoynYG9mCA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       storybook: ^8.4.6
     dependencies:
-      '@storybook/builder-vite': 8.4.6(storybook@8.4.6)(vite@5.4.12)
-      '@storybook/web-components': 8.4.6(lit@3.3.1)(storybook@8.4.6)
+      '@storybook/builder-vite': 8.4.6(storybook@8.6.15)(vite@5.4.12)
+      '@storybook/web-components': 8.4.6(lit@3.3.1)(storybook@8.6.15)
       magic-string: 0.30.10
-      storybook: 8.4.6
+      storybook: 8.6.15
     transitivePeerDependencies:
       - lit
       - vite
     dev: true
 
-  /@storybook/web-components@8.4.6(lit@3.3.1)(storybook@8.4.6):
+  /@storybook/web-components@8.4.6(lit@3.3.1)(storybook@8.6.15):
     resolution: {integrity: sha512-Mblv35pwX+Pyo9D5qQjUE3WzHxACe+DgGdzU03QG5C8wEBuk4ji/s9TMoTwKVLBvXp13CuDsA1qPiH86sizdjA==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       lit: ^2.0.0 || ^3.0.0
       storybook: ^8.4.6
     dependencies:
-      '@storybook/components': 8.4.6(storybook@8.4.6)
+      '@storybook/components': 8.4.6(storybook@8.6.15)
       '@storybook/global': 5.0.0
-      '@storybook/manager-api': 8.4.6(storybook@8.4.6)
-      '@storybook/preview-api': 8.4.6(storybook@8.4.6)
-      '@storybook/theming': 8.4.6(storybook@8.4.6)
+      '@storybook/manager-api': 8.4.6(storybook@8.6.15)
+      '@storybook/preview-api': 8.4.6(storybook@8.6.15)
+      '@storybook/theming': 8.4.6(storybook@8.6.15)
       lit: 3.3.1
-      storybook: 8.4.6
+      storybook: 8.6.15
       tiny-invariant: 1.3.3
       ts-dedent: 2.2.0
     dev: true
@@ -1687,8 +1695,8 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       call-bind-apply-helpers: 1.0.1
-      es-define-property: 1.0.0
-      get-intrinsic: 1.2.4
+      es-define-property: 1.0.1
+      get-intrinsic: 1.2.7
       set-function-length: 1.2.2
     dev: true
 
@@ -2101,9 +2109,9 @@ packages:
     resolution: {integrity: sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==}
     engines: {node: '>= 0.4'}
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
       es-errors: 1.3.0
-      gopd: 1.0.1
+      gopd: 1.2.0
     dev: true
 
   /define-lazy-prop@2.0.0:
@@ -2270,13 +2278,6 @@ packages:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.13
-    dev: true
-
-  /es-define-property@1.0.0:
-    resolution: {integrity: sha512-jxayLKShrEqqzJ0eumQbVhTYQM27CfT1T35+gCgDFoL82JLsXqTJ76zv6A0YLOgEnLUMvLzsDsGIrl8NFpT2gQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      get-intrinsic: 1.2.7
     dev: true
 
   /es-define-property@1.0.1:
@@ -2640,17 +2641,6 @@ packages:
     engines: {node: 6.* || 8.* || >= 10.*}
     dev: true
 
-  /get-intrinsic@1.2.4:
-    resolution: {integrity: sha512-5uYhsJH8VJBTv7oslg4BznJYhDoRI6waYCxMmCdnTrcCrHA/fCFKoTFz2JKKE0HdDFUF7/oQuhzumXJK7paBRQ==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      es-errors: 1.3.0
-      function-bind: 1.1.2
-      has-proto: 1.0.1
-      has-symbols: 1.0.3
-      hasown: 2.0.0
-    dev: true
-
   /get-intrinsic@1.2.7:
     resolution: {integrity: sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==}
     engines: {node: '>= 0.4'}
@@ -2744,12 +2734,6 @@ packages:
       slash: 3.0.0
     dev: true
 
-  /gopd@1.0.1:
-    resolution: {integrity: sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==}
-    dependencies:
-      get-intrinsic: 1.2.7
-    dev: true
-
   /gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -2806,16 +2790,11 @@ packages:
   /has-property-descriptors@1.0.2:
     resolution: {integrity: sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==}
     dependencies:
-      es-define-property: 1.0.0
+      es-define-property: 1.0.1
     dev: true
 
   /has-proto@1.0.1:
     resolution: {integrity: sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==}
-    engines: {node: '>= 0.4'}
-    dev: true
-
-  /has-symbols@1.0.3:
-    resolution: {integrity: sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==}
     engines: {node: '>= 0.4'}
     dev: true
 
@@ -2828,14 +2807,7 @@ packages:
     resolution: {integrity: sha512-kFjcSNhnlGV1kyoGk7OXKSawH5JOb/LzUc5w9B02hOTO0dfFRjbHQKvg1d6cf3HbeUmtU9VbbV3qzZ2Teh97WQ==}
     engines: {node: '>= 0.4'}
     dependencies:
-      has-symbols: 1.0.3
-    dev: true
-
-  /hasown@2.0.0:
-    resolution: {integrity: sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==}
-    engines: {node: '>= 0.4'}
-    dependencies:
-      function-bind: 1.1.2
+      has-symbols: 1.1.0
     dev: true
 
   /hasown@2.0.2:
@@ -3027,7 +2999,7 @@ packages:
   /is-core-module@2.13.1:
     resolution: {integrity: sha1-rQ11Msb+qdoevcgnQtdFJcYnM4Q=}
     dependencies:
-      hasown: 2.0.0
+      hasown: 2.0.2
     dev: true
 
   /is-date-object@1.0.5:
@@ -3855,7 +3827,7 @@ packages:
     dependencies:
       call-bind: 1.0.8
       define-properties: 1.2.1
-      has-symbols: 1.0.3
+      has-symbols: 1.1.0
       object-keys: 1.1.1
     dev: true
 
@@ -4530,7 +4502,7 @@ packages:
       es-errors: 1.3.0
       function-bind: 1.1.2
       get-intrinsic: 1.2.7
-      gopd: 1.0.1
+      gopd: 1.2.0
       has-property-descriptors: 1.0.2
     dev: true
 
@@ -4713,28 +4685,28 @@ packages:
       tweetnacl: 0.14.5
     dev: true
 
-  /storybook-addon-tag-badges@1.3.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6):
+  /storybook-addon-tag-badges@1.3.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15):
     resolution: {integrity: sha512-P+kUX8qPbySAN1SLBgcfhD/vCbFuUXsAvXGw+UeV7wv9SD461qyvL3KK3lZJ5pZplpz4n2qvZ6vu58Yf6V+VXQ==}
     engines: {node: '>=20'}
     peerDependencies:
       storybook: ^8.4.4
     dependencies:
       '@storybook/icons': 1.2.12(react-dom@18.2.0)(react@18.3.1)
-      storybook: 8.4.6
+      storybook: 8.6.15
     transitivePeerDependencies:
       - react
       - react-dom
     dev: true
 
-  /storybook-dark-mode@4.0.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.4.6):
+  /storybook-dark-mode@4.0.1(react-dom@18.2.0)(react@18.3.1)(storybook@8.6.15):
     resolution: {integrity: sha512-9l3qY8NdgwZnY+NlO1XHB3eUb6FmZo9GazJeUSeFkjRqwA5FmnMSeq0YVqEOqfwniM/TvQwOiTYd5g/hC2wugA==}
     dependencies:
-      '@storybook/components': 8.2.4(storybook@8.4.6)
+      '@storybook/components': 8.2.4(storybook@8.6.15)
       '@storybook/core-events': 8.0.9
       '@storybook/global': 5.0.0
       '@storybook/icons': 1.2.9(react-dom@18.2.0)(react@18.3.1)
-      '@storybook/manager-api': 8.4.6(storybook@8.4.6)
-      '@storybook/theming': 8.4.6(storybook@8.4.6)
+      '@storybook/manager-api': 8.4.6(storybook@8.6.15)
+      '@storybook/theming': 8.4.6(storybook@8.6.15)
       fast-deep-equal: 3.1.3
       memoizerific: 1.11.3
     transitivePeerDependencies:
@@ -4743,8 +4715,8 @@ packages:
       - storybook
     dev: true
 
-  /storybook@8.4.6:
-    resolution: {integrity: sha512-J6juZSZT2u3PUW0QZYZZYxBq6zU5O0OrkSgkMXGMg/QrS9to9IHmt4FjEMEyACRbXo8POcB/fSXa3VpGe7bv3g==}
+  /storybook@8.6.15:
+    resolution: {integrity: sha512-Ob7DMlwWx8s7dMvcQ3xPc02TvUeralb+xX3oaPRk9wY9Hc6M1IBC/7cEoITkSmRS2v38DHubC+mtEKNc1u2gQg==}
     hasBin: true
     peerDependencies:
       prettier: ^2 || ^3
@@ -4752,7 +4724,7 @@ packages:
       prettier:
         optional: true
     dependencies:
-      '@storybook/core': 8.4.6
+      '@storybook/core': 8.6.15(storybook@8.6.15)
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -5388,7 +5360,7 @@ packages:
       available-typed-arrays: 1.0.5
       call-bind: 1.0.8
       for-each: 0.3.3
-      gopd: 1.0.1
+      gopd: 1.2.0
       has-tostringtag: 1.0.0
     dev: true
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2025 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Bumps v2 storybook version to patch an issue where .env secrets could be included in the bundle and leaked by storybook public instances hosted in Chromatic. This patch is to close that vulnerability. Our instance was not impacted by the vulnerability. See security advisory for details: https://www.chromatic.com/blog/storybook-security-advisory/?ref=storybookblog.ghost.io

## How To Test

- Run `yarn storybook` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Verify storybook is functioning correctly

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A
