### PR TITLE
[Docs - Next] Corrects and adds detail to color token changes migration docs

### DIFF
--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -201,13 +201,40 @@ For detailed guidance on using Lit 3 with Webpack 4, refer to the [Lit upgrade g
   </tbody>
 </table>
 
-### Deprecated Color Tokens
+### Color Tokens
 
-* All the color tokens in the **rose** family (`--jh-color-rose-50` to `--jh-color-rose-950`) have been deprecated.
-* All the color tokens in the **lime** family (`--jh-color-lime-50` to `--jh-color-lime-950`) have been deprecated.
-* All the color tokens in the **blue** family (`--jh-color-blue-50` to `--jh-color-blue-950`) have been deprecated.
+Upgrading to v2 requires updating token names and handling deprecated color families.
 
-* All the colors in the **azure** family have been renamed to **blue**: `--jh-color-azure-50` to `--jh-color-azure-950` are now `--jh-color-blue-50` to `--jh-color-blue-950`.
+#### Updated Token Names
+
+**Azure** has been renamed to **blue**. To migrate, replace all `--jh-color-azure-` prefixes with `--jh-color-blue-`.
+
+#### Deprecated Families
+
+The following families have been removed: 
+
+* `--jh-color-rose-[50-950]`
+* `--jh-color-lime-[50-950]`
+* `--jh-color-blue-[50-950]`. **Note:** These tokens have been replaced by the former azure values. If you were using the original v1 blue tokens, you will need to manually remap them to a different family as the new blue is significantly different.
+
+<table>
+  <thead>
+    <tr>
+      <th>Deprecated Token</th>
+      <th>New Token</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--jh-color-gray-0</td>
+      <td>--jh-color-white-alpha-100</td>
+    </tr>
+    <tr>
+      <td>--jh-color-gray-1000</td>
+      <td>--jh-color-black-alpha-100</td>
+    </tr>
+  </tbody>
+</table>
 
 <table>
   <thead>

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -203,11 +203,11 @@ For detailed guidance on using Lit 3 with Webpack 4, refer to the [Lit upgrade g
 
 ### Deprecated Color Tokens
 
-* All the color tokens in the **rose** family (`--jh-rose-50` to `--jh-rose-950`) have been deprecated.
-* All the color tokens in the **lime** family (`--jh-lime-50` to `--jh-lime-950`) have been deprecated.
-* All the color tokens in the **blue** family (`--jh-blue-50` to `--jh-blue-950`) have been deprecated.
+* All the color tokens in the **rose** family (`--jh-color-rose-50` to `--jh-color-rose-950`) have been deprecated.
+* All the color tokens in the **lime** family (`--jh-color-lime-50` to `--jh-color-lime-950`) have been deprecated.
+* All the color tokens in the **blue** family (`--jh-color-blue-50` to `--jh-color-blue-950`) have been deprecated.
 
-* All the colors in the **azure** family have been renamed to **blue**: `--jh-azure-50` to `--jh-azure-950` are now `--jh-blue-50` to `--jh-blue-950`.
+* All the colors in the **azure** family have been renamed to **blue**: `--jh-color-azure-50` to `--jh-color-azure-950` are now `--jh-color-blue-50` to `--jh-color-blue-950`.
 
 <table>
   <thead>

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -201,7 +201,7 @@ For detailed guidance on using Lit 3 with Webpack 4, refer to the [Lit upgrade g
   </tbody>
 </table>
 
-### Deprecated Color Tokens
+### Color Token Changes
 
 Upgrading to v2 requires updating token names and handling deprecated color families.
 

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -201,21 +201,23 @@ For detailed guidance on using Lit 3 with Webpack 4, refer to the [Lit upgrade g
   </tbody>
 </table>
 
-### Color Tokens
+### Deprecated Color Tokens
 
 Upgrading to v2 requires updating token names and handling deprecated color families.
 
-#### Updated Token Names
+#### Updated Color Token Names
 
-**Azure** has been renamed to **blue**. To migrate, replace all `--jh-color-azure-` prefixes with `--jh-color-blue-`.
+**Azure** tokens have been renamed to **blue**. To migrate, replace all `--jh-color-azure-` prefixes with `--jh-color-blue-`.
 
-#### Deprecated Families
+#### Deprecated Color Families
 
-The following families have been removed: 
+The following color families have been removed: 
 
 * `--jh-color-rose-[50-950]`
 * `--jh-color-lime-[50-950]`
 * `--jh-color-blue-[50-950]`. **Note:** These tokens have been replaced by the former azure values. If you were using the original v1 blue tokens, you will need to manually remap them to a different family as the new blue is significantly different.
+
+#### Deprecated Color Tokens
 
 <table>
   <thead>

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -104,8 +104,8 @@ In addition we have made the following changes to our color families:
 
 - Introduced new color families for black and white colors with alpha channels.
 - Updated the gray color family to use more neutral colors.
-- Removed 3 color families (lime, blue and rose) to help create more disctinction between the available color families.
-- Renamed the `azure` color family to `blue`. 
+- Renamed the `azure` color family to `blue`. The values for all `--jh-color-blue-x` tokens have been updated to the previous azure values in HEX8 format.
+- Removed the lime, rose, and the original blue color families to help create more disctinction between the available color families.
 
 #### New Black and White Color Tokens
 


### PR DESCRIPTION
## What It Does

Corrects the naming of the listed deprecated color tokens (rose, lime, and blue) in the migration and release docs. Adds detail to the renaming of the azure token docs. 

## How To Test

- Run `pnpm storybook:jh-ui` and navigate to http://localhost:6006/ or
  http://<local-ip>:6006/
- Review the migration and release docs and ensure that the deprecated color tokens (rose, lime, and blue) are correctly named. Ensure that the migration details of the `azure` color tokens to the `blue` color tokens is clear. 

## Notes/Caveats

N/A

## Resources

N/A

## Dependencies

N/A