### PR TITLE
[V2 Migration Docs] Adds deprecated jh-input styling hooks and switch sizing change to v2 migration docs

### DIFF
--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -409,9 +409,7 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
 * `jh-input-clear-shadow-focus`. Use `jh-input-clear-color-focus` instead. 
 * `jh-input-shadow-focus`. Use `jh-input-field-color-border-focus` instead. 
 * `jh-input-size-min-height-text-area-small`, `jh-input-size-min-height-text-area-medium`, and `jh-input-size-min-height-text-area-large`. Use `jh-input-textarea-field-dimension-min-height` instead. 
-
-### Renamed jh-input styling hooks
-Tokens targetting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
+* The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
 
 </div>
 

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -398,18 +398,71 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
 
 ### Deprecated jh-input styling hooks
 
-* `jh-input-field-dimension-padding-top`
-* `jh-input-field-dimension-padding-bottom`
-* `jh-input-field-dimension-padding-left`
-* `jh-input-field-dimension-padding-right`
-* `jh-input-clear-color-background-disabled` 
-* `jh-input-clear-color-border-disabled`
-* `jh-input-clear-icon-color-fill-disabled`
-* `jh-input-clear-opacity-disabled`
-* `jh-input-clear-shadow-focus`. Use `jh-input-clear-color-focus` instead. 
-* `jh-input-shadow-focus`. Use `jh-input-field-color-border-focus` instead. 
-* `jh-input-size-min-height-text-area-small`, `jh-input-size-min-height-text-area-medium`, and `jh-input-size-min-height-text-area-large`. Use `jh-input-textarea-field-dimension-min-height` instead. 
+<table>
+  <thead>
+    <tr>
+      <th>Deprecated Token</th>
+      <th>New Token</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--jh-input-clear-shadow-focus</td>
+      <td>--jh-input-clear-color-focus</td>
+    </tr>
+    <tr>
+      <td>--jh-input-shadow-focus</td>
+      <td>--jh-input-field-color-border-focus</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-small</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-medium</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-large</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-top</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-bottom</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-left</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-right</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-color-background-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-color-border-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-icon-color-fill-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-opacity-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+  </tbody>
+</table>
+
 * The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
+* `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
 </div>
 

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -402,6 +402,16 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
 * `jh-input-field-dimension-padding-bottom`
 * `jh-input-field-dimension-padding-left`
 * `jh-input-field-dimension-padding-right`
+* `jh-input-clear-color-background-disabled` 
+* `jh-input-clear-color-border-disabled`
+* `jh-input-clear-icon-color-fill-disabled`
+* `jh-input-clear-opacity-disabled`
+* `jh-input-clear-shadow-focus`. Use `jh-input-clear-color-focus` instead. 
+* `jh-input-shadow-focus`. Use `jh-input-field-color-border-focus` instead. 
+* `jh-input-size-min-height-text-area-small`, `jh-input-size-min-height-text-area-medium`, and `jh-input-size-min-height-text-area-large`. Use `jh-input-textarea-field-dimension-min-height` instead. 
+
+### Renamed jh-input styling hooks
+Tokens targetting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
 
 </div>
 

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -351,14 +351,17 @@ import '@jack-henry/jh-elements/components/divider/divider.js';
 
 ## Migrating jh-input 
 
-The `jh-input` component has been refactored into a base class to enhance its flexibility and reduce API overhead. In doing so, the `type` property is no longer supported. Specialized input types will become available as separate, discrete components. Users who rely on the `type` property will need to either:
+The jh-input component has been refactored into a base class to increase flexibility and reduce API overhead. This change introduces several breaking changes to properties and styling hooks.
 
-1. Migrate to the specialized input components as they become available. For example, if using `<jh-input type="search"></jh-input>` users can migrate to `<jh-input-search></jh-input-search>`. Refer to the migration table below:
+### New Discrete Components
+The `type` property is no longer supported on the `jh-input`. You must now use specialized components or extend the base class.
+
+1. Discrete Components - replace `<jh-input type="..."` with the corresponding component below:
 <table>
   <thead>
     <tr>
-      <th>Input `type`</th>
-      <th>Discrete Component</th>
+      <th>Deprecated Input `type`</th>
+      <th>New Discrete Component</th>
     </tr>
   </thead>
   <tbody>
@@ -392,12 +395,13 @@ The `jh-input` component has been refactored into a base class to enhance its fl
     </tr>
   </tbody>
 </table>
-2. Extend the jh-input component to create the needed specialized input type. Refer to the [Extending Components Guide](/docs/guides-extending-components--docs) for information on how to extend components. 
 
-Additionally, the `placeholder` property has been deprecated due to accessibility concerns. Users should leverage the `helper-text` and `label` properties to provide guidance on the expected type of user data. 
+2. Extend the `jh-input` Component. To create a specialized input type, refer to the [Extending Components Guide](/docs/guides-extending-components--docs) for information on how to extend components. 
+
+### Deprecated Properties
+The `placeholder` property has been deprecated due to accessibility concerns. Please leverage the `helper-text` and `label` properties to provide clear, persistent guidance for users. 
 
 ### Deprecated jh-input styling hooks
-
 <table>
   <thead>
     <tr>
@@ -461,7 +465,7 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
   </tbody>
 </table>
 
-* The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
+* The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targeting the clear button i.e. `jh-input-clear-*`. 
 * `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
 ## Migrating jh-icons

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -464,8 +464,6 @@ Additionally, the `placeholder` property has been deprecated due to accessibilit
 * The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
 * `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
-</div>
-
 ## Migrating jh-icons
 
 The following icon has been renamed. Please update all instances in your codebase.
@@ -484,3 +482,5 @@ The following icon has been renamed. Please update all instances in your codebas
     </tr>
   </tbody>
 </table>
+
+</div>

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -468,6 +468,9 @@ The `placeholder` property has been deprecated due to accessibility concerns. Pl
 * The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targeting the clear button i.e. `jh-input-clear-*`. 
 * `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
+## Migrating jh-switch
+The default width of `jh-switch` has been reduced from 56px to 48px. Users should audit existing implementations to ensure horizontal alignment and spacing remain consistent within their layouts.
+
 ## Migrating jh-icons
 
 The following icon has been renamed. Please update all instances in your codebase.

--- a/packages/jh-elements/docs/whats-new/v2-release.mdx
+++ b/packages/jh-elements/docs/whats-new/v2-release.mdx
@@ -381,7 +381,7 @@ In version 1, the text in `jh-list-item` and `jh-tag` would atuomatically trunca
 This behavior was removed due to accessibility and design concerns. The text in `jh-list-item` does now wrap to a new line, while `jh-tag` will expand to contain the full text.
 
 ### jh-switch
-The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element.
+The width of `jh-switch` has been updated to 48px from 56px (as present in V1). And the `box-shadow` property has been removed from the internal thumb element.
 
 ### Keyboard focus styles moved to outline
 

--- a/packages/jh-elements/docs/whats-new/v2-release.mdx
+++ b/packages/jh-elements/docs/whats-new/v2-release.mdx
@@ -369,75 +369,11 @@ For instance, to restrict the input to a phone number format, set the input-mask
 
 ```
 
+Review the [jh-input documentation](/docs/components-input--docs) for more information on its features. 
+
 #### Deprecated Styling Hooks:
 
-<table>
-  <thead>
-    <tr>
-      <th>Deprecated Token</th>
-      <th>New Token</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>--jh-input-clear-shadow-focus</td>
-      <td>--jh-input-clear-color-focus</td>
-    </tr>
-    <tr>
-      <td>--jh-input-shadow-focus</td>
-      <td>--jh-input-field-color-border-focus</td>
-    </tr>
-    <tr>
-      <td>--jh-input-size-min-height-text-area-small</td>
-      <td>--jh-input-textarea-field-dimension-min-height</td>
-    </tr>
-    <tr>
-      <td>--jh-input-size-min-height-text-area-medium</td>
-      <td>--jh-input-textarea-field-dimension-min-height</td>
-    </tr>
-    <tr>
-      <td>--jh-input-size-min-height-text-area-large</td>
-      <td>--jh-input-textarea-field-dimension-min-height</td>
-    </tr>
-    <tr>
-      <td>--jh-input-field-dimension-padding-top</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-field-dimension-padding-bottom</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-field-dimension-padding-left</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-field-dimension-padding-right</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-clear-color-background-disabled</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-clear-color-border-disabled</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-clear-icon-color-fill-disabled</td>
-      <td>No replacement token</td>
-    </tr>
-    <tr>
-      <td>--jh-input-clear-opacity-disabled</td>
-      <td>No replacement token</td>
-    </tr>
-  </tbody>
-</table>
-
-* The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
-* `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
-
-Review the [jh-input documentation](/docs/components-input--docs) for more information on its features. 
+A detailed list of [jh-input deprecated styling hooks](/docs/what-s-new-migrating--docs#deprecated-jh-input-styling-hooks) is available under our migration docs.
 
 ### jh-list-item and jh-tag
 

--- a/packages/jh-elements/docs/whats-new/v2-release.mdx
+++ b/packages/jh-elements/docs/whats-new/v2-release.mdx
@@ -379,6 +379,10 @@ A detailed list of [jh-input deprecated styling hooks](/docs/what-s-new-migratin
 
 In version 1, the text in `jh-list-item` and `jh-tag` would atuomatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
 This behavior was removed due to accessibility and design concerns. The text in `jh-list-item` does now wrap to a new line, while `jh-tag` will expand to contain the full text.
+
+### jh-switch
+The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element.
+
 ### Keyboard focus styles moved to outline
 
 In v1, the focus styles for interactive components were implemented using a `box-shadow` to create a focus ring around the component.

--- a/packages/jh-elements/docs/whats-new/v2-release.mdx
+++ b/packages/jh-elements/docs/whats-new/v2-release.mdx
@@ -371,10 +371,18 @@ For instance, to restrict the input to a phone number format, set the input-mask
 
 #### Deprecated Styling Hooks:
 
-- `jh-input-field-dimension-padding-top`
-- `jh-input-field-dimension-padding-bottom`
-- `jh-input-field-dimension-padding-left`
-- `jh-input-field-dimension-padding-right`
+* `jh-input-field-dimension-padding-top`
+* `jh-input-field-dimension-padding-bottom`
+* `jh-input-field-dimension-padding-left`
+* `jh-input-field-dimension-padding-right`
+* `jh-input-clear-color-background-disabled` 
+* `jh-input-clear-color-border-disabled`
+* `jh-input-clear-icon-color-fill-disabled`
+* `jh-input-clear-opacity-disabled`
+* `jh-input-clear-shadow-focus`. Use `jh-input-clear-color-focus` instead. 
+* `jh-input-shadow-focus`. Use `jh-input-field-color-border-focus` instead. 
+* `jh-input-size-min-height-text-area-small`, `jh-input-size-min-height-text-area-medium`, and `jh-input-size-min-height-text-area-large`. Use `jh-input-textarea-field-dimension-min-height` instead. 
+* The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
 
 Review the [jh-input documentation](/docs/components-input--docs) for more information on its features. 
 

--- a/packages/jh-elements/docs/whats-new/v2-release.mdx
+++ b/packages/jh-elements/docs/whats-new/v2-release.mdx
@@ -371,18 +371,71 @@ For instance, to restrict the input to a phone number format, set the input-mask
 
 #### Deprecated Styling Hooks:
 
-* `jh-input-field-dimension-padding-top`
-* `jh-input-field-dimension-padding-bottom`
-* `jh-input-field-dimension-padding-left`
-* `jh-input-field-dimension-padding-right`
-* `jh-input-clear-color-background-disabled` 
-* `jh-input-clear-color-border-disabled`
-* `jh-input-clear-icon-color-fill-disabled`
-* `jh-input-clear-opacity-disabled`
-* `jh-input-clear-shadow-focus`. Use `jh-input-clear-color-focus` instead. 
-* `jh-input-shadow-focus`. Use `jh-input-field-color-border-focus` instead. 
-* `jh-input-size-min-height-text-area-small`, `jh-input-size-min-height-text-area-medium`, and `jh-input-size-min-height-text-area-large`. Use `jh-input-textarea-field-dimension-min-height` instead. 
+<table>
+  <thead>
+    <tr>
+      <th>Deprecated Token</th>
+      <th>New Token</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td>--jh-input-clear-shadow-focus</td>
+      <td>--jh-input-clear-color-focus</td>
+    </tr>
+    <tr>
+      <td>--jh-input-shadow-focus</td>
+      <td>--jh-input-field-color-border-focus</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-small</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-medium</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-size-min-height-text-area-large</td>
+      <td>--jh-input-textarea-field-dimension-min-height</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-top</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-bottom</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-left</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-field-dimension-padding-right</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-color-background-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-color-border-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-icon-color-fill-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+    <tr>
+      <td>--jh-input-clear-opacity-disabled</td>
+      <td>No replacement token</td>
+    </tr>
+  </tbody>
+</table>
+
 * The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targetting the clear button i.e. `jh-input-clear-*`. 
+* `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
 Review the [jh-input documentation](/docs/components-input--docs) for more information on its features. 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- Adds deprecated jh-input styling hooks to v2 migration docs. 
- Adds switch size reduction to v2 migration docs. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-input-clear-border-radius` is not a deprecated token and will be added to jh-input in a separate PR. 


