### PR TITLE
[V2] Switch - updates to width and remove box-shadow

### DIFF
--- a/packages/jh-elements/components/switch/switch.js
+++ b/packages/jh-elements/components/switch/switch.js
@@ -53,7 +53,7 @@ export class JhSwitch extends LitElement {
         z-index: 2;
       }
       span {
-        width: var(--jh-dimension-1400);
+        width: var(--jh-dimension-1200);
         height: var(--jh-dimension-600);
         display: inline-block;
         position: relative;
@@ -87,7 +87,6 @@ export class JhSwitch extends LitElement {
         left: 2px;
         width: var(--jh-dimension-500);
         height: var(--jh-dimension-500);
-        box-shadow: var(--jh-shadow-low);
         transition: all 0.3s cubic-bezier(0.1, 0.5, 0.1, 1);
       }
       /* Unselected states */
@@ -168,7 +167,7 @@ export class JhSwitch extends LitElement {
         pointer-events: none;
       }
       button[checked] + span::after {
-        transform: translateX(32px);
+        transform: translateX(24px);
       }
       .label-container {
         margin-top: var(--jh-dimension-50);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adjusts the width of the switch to 48px and removes the box-shadow.

**Idea number or other reference :** 209

## How To Test

Select all that apply:

- [x] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies
N/A


