### PR TITLE
[V2 Bugfix] Corrects jh-input-textarea focus styles

### DIFF
--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -99,12 +99,17 @@ export class JhInputTextarea extends JhInput {
         );
       }
       textarea:focus-visible {
-        box-shadow: var(--jh-input-shadow-focus, var(--jh-shadow-focus));
         border-color: var(
           --jh-input-field-color-border-focus,
           var(--jh-color-content-brand-hover)
         );
-        outline: none;
+        outline-color: var(
+          --jh-input-color-focus,
+          var(--jh-border-focus-color)
+        );
+        outline-style: var(--jh-border-focus-style);
+        outline-width: var(--jh-border-focus-width);
+        outline-offset: 1px;
       }
       :host([disabled]) textarea {
         border-color: var(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Corrects `jh-input-textarea` focus styles by removing deprecated `--jh-shadow-focus` token and adding related outline tokens. 

**Idea number or other reference :** N/A

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

Add focus to jh-input-textarea and ensure focus styles are applied. 

## Notes/Dependencies

N/A

