### PR TITLE
[Card] Removes slot styles when slotted content is removed

### DIFF
--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -221,15 +221,15 @@ export class JhCard extends LitElement {
         reflect: true,
       },
       /** Adds additional information about the card below the title.  */
-      headerSubtitle: { 
+      headerSubtitle: {
         type: String,
         attribute: 'header-subtitle',
-       },
+      },
       /** Provides context for the content of the card.  */
-      headerTitle: { 
+      headerTitle: {
         type: String,
         attribute: 'header-title',
-       },
+      },
       /** Informs assistive technologies what heading level the card title represents. Defaults to h2.  */
       titleHeadingLevel: {
         type: Number,
@@ -237,7 +237,7 @@ export class JhCard extends LitElement {
       },
     };
   }
-  
+
   constructor() {
     super();
     /** @type {0|8|16|24|32|40|48|56|64|72|80|88|96} */
@@ -258,6 +258,32 @@ export class JhCard extends LitElement {
     this.headerTitle = null;
   }
 
+  firstUpdated() {
+    this.#updateSlotClassList();
+  }
+
+  #updateSlotClassList() {
+    const slots = this.shadowRoot.querySelectorAll('slot');
+    slots.forEach((slot) => {
+      let hasContent = this.#checkSlotContent(slot);
+      slot.classList.toggle('display-slot', hasContent);
+    })
+  }
+
+  #checkSlotContent(slot) {
+    if (slot.assignedElements().length > 0) {
+      return true;
+    }
+
+    return slot.assignedNodes().some((node) => node.nodeType === Node.TEXT_NODE && node.textContent.trim() !== '');
+  }
+
+  #handleSlotChange(e) {
+    let slot = e.target;
+    let hasContent = this.#checkSlotContent(slot);
+    slot.classList.toggle('display-slot', hasContent);
+  }
+
   #getTitle() {
     switch (this.titleHeadingLevel) {
       case 1:
@@ -275,10 +301,6 @@ export class JhCard extends LitElement {
       default:
         return html`<h2>${this.headerTitle}</h2>`;
     }
-  }
-
-  #handleSlotChange(e) {
-    e.target.classList.add("display-slot");
   }
 
   render() {

--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -258,18 +258,6 @@ export class JhCard extends LitElement {
     this.headerTitle = null;
   }
 
-  firstUpdated() {
-    this.#updateSlotClassList();
-  }
-
-  #updateSlotClassList() {
-    const slots = this.shadowRoot.querySelectorAll('slot');
-    slots.forEach((slot) => {
-      let hasContent = this.#checkSlotContent(slot);
-      slot.classList.toggle('display-slot', hasContent);
-    })
-  }
-
   #checkSlotContent(slot) {
     if (slot.assignedElements().length > 0) {
       return true;

--- a/packages/jh-elements/components/card/card.stories.js
+++ b/packages/jh-elements/components/card/card.stories.js
@@ -5,6 +5,7 @@
 import { html, css } from 'lit';
 import './card.js';
 import '../tooltip/tooltip.js';
+import '../button/button.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 const storyStyles = css`
@@ -220,3 +221,34 @@ Padding.argTypes = {
 Padding.parameters = {
   styles: storyStyles,
 };
+
+
+
+export const Test = {
+  render: (args) => {
+
+  function handleClickRemove() {
+    let cardEl = document.querySelector("jh-card");
+    let defaultSlot = cardEl.querySelector("div");
+    defaultSlot.remove();
+  }
+
+  let handleClickAdd = () => {
+    let cardEl = document.querySelector("jh-card");
+    let newContent = document.createElement("div");
+    newContent.textContent = "New content added to default slot";
+    cardEl.appendChild(newContent);
+  }
+  
+  return html`
+    <section class="overview-story">
+      <jh-card
+        show-header-divider
+        header-title="Title"
+        header-subtitle="Subtitle"
+      ><div>Test</div><footer slot="jh-card-footer"><jh-button @click=${handleClickRemove} id="remove-content" label="Remove Content"></jh-button><jh-button id="add-content" label="Add Content" @click=${handleClickAdd}></jh-button></footer>
+    </jh-card>
+    </section>
+    `
+  }
+}

--- a/packages/jh-elements/components/card/card.stories.js
+++ b/packages/jh-elements/components/card/card.stories.js
@@ -4,8 +4,6 @@
 
 import { html, css } from 'lit';
 import './card.js';
-import '../tooltip/tooltip.js';
-import '../button/button.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 const storyStyles = css`
@@ -221,34 +219,3 @@ Padding.argTypes = {
 Padding.parameters = {
   styles: storyStyles,
 };
-
-
-
-export const Test = {
-  render: (args) => {
-
-  function handleClickRemove() {
-    let cardEl = document.querySelector("jh-card");
-    let defaultSlot = cardEl.querySelector("div");
-    defaultSlot.remove();
-  }
-
-  let handleClickAdd = () => {
-    let cardEl = document.querySelector("jh-card");
-    let newContent = document.createElement("div");
-    newContent.textContent = "New content added to default slot";
-    cardEl.appendChild(newContent);
-  }
-  
-  return html`
-    <section class="overview-story">
-      <jh-card
-        show-header-divider
-        header-title="Title"
-        header-subtitle="Subtitle"
-      ><div>Test</div><footer slot="jh-card-footer"><jh-button @click=${handleClickRemove} id="remove-content" label="Remove Content"></jh-button><jh-button id="add-content" label="Add Content" @click=${handleClickAdd}></jh-button></footer>
-    </jh-card>
-    </section>
-    `
-  }
-}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Ensures the .display-slot class stays in sync with the actual slotted content (elements or text) when it is both added or removed. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Review Test story and confirm that the display-slot class is added and removed from the default slot when content is added and removed via the add/remove buttons. 

## Notes/Dependencies

N/A


