### PR TITLE
[Card] Removes box-shadow, updates border radius, adds border color styling hook

### DIFF
--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -9,7 +9,7 @@ import '../divider/divider.js';
 /**
  * @cssprop --jh-card-color-background - The card background-color. Defaults to `--jh-color-container-primary-enabled`.
  * @cssprop --jh-card-border-radius - The card border-radius. Defaults to `--jh-border-radius-200`.
- * @cssprop --jh-card-border-color - The card border color. Defaults to `--jh-border-decorative-color`.
+ * @cssprop --jh-card-color-border - The card border color. Defaults to `--jh-border-decorative-color`.
  * @cssprop --jh-card-media-aspect-ratio - The media slot aspect-ratio. Defaults to `auto`.
  * @cssprop --jh-card-media-space-padding - The media slot padding. Defaults to `0`.
  * @cssprop --jh-card-header-color-text - The header text color. Defaults to `--jh-color-content-primary-enabled`.
@@ -44,7 +44,7 @@ export class JhCard extends LitElement {
           --jh-card-border-radius,
           var(--border-radius)
         );
-        border-color: var(--jh-card-border-color, var(--jh-border-decorative-color));
+        border-color: var(--jh-card-color-border, var(--jh-border-decorative-color));
         border-width: var(--jh-border-decorative-width);
         border-style: var(--jh-border-decorative-style);
         word-break: break-word;

--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -9,7 +9,7 @@ import '../divider/divider.js';
 /**
  * @cssprop --jh-card-color-background - The card background-color. Defaults to `--jh-color-container-primary-enabled`.
  * @cssprop --jh-card-border-radius - The card border-radius. Defaults to `--jh-border-radius-200`.
- * @cssprop --jh-card-shadow - The card box-shadow. Defaults to `--jh-shadow-low`.
+ * @cssprop --jh-card-border-color - The card border color. Defaults to `--jh-border-decorative-color`.
  * @cssprop --jh-card-media-aspect-ratio - The media slot aspect-ratio. Defaults to `auto`.
  * @cssprop --jh-card-media-space-padding - The media slot padding. Defaults to `0`.
  * @cssprop --jh-card-header-color-text - The header text color. Defaults to `--jh-color-content-primary-enabled`.
@@ -44,7 +44,9 @@ export class JhCard extends LitElement {
           --jh-card-border-radius,
           var(--border-radius)
         );
-        box-shadow: var(--jh-card-shadow, var(--jh-shadow-low));
+        border-color: var(--jh-card-border-color, var(--jh-border-decorative-color));
+        border-width: var(--jh-border-decorative-width);
+        border-style: var(--jh-border-decorative-style);
         word-break: break-word;
         display: block;
       }

--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -8,7 +8,7 @@ import '../divider/divider.js';
 
 /**
  * @cssprop --jh-card-color-background - The card background-color. Defaults to `--jh-color-container-primary-enabled`.
- * @cssprop --jh-card-border-radius - The card border-radius. Defaults to `--jh-border-radius-400`.
+ * @cssprop --jh-card-border-radius - The card border-radius. Defaults to `--jh-border-radius-200`.
  * @cssprop --jh-card-shadow - The card box-shadow. Defaults to `--jh-shadow-low`.
  * @cssprop --jh-card-media-aspect-ratio - The media slot aspect-ratio. Defaults to `auto`.
  * @cssprop --jh-card-media-space-padding - The media slot padding. Defaults to `0`.
@@ -35,7 +35,7 @@ export class JhCard extends LitElement {
   static get styles() {
     return css`
       :host {
-        --border-radius: var(--jh-border-radius-400);
+        --border-radius: var(--jh-border-radius-200);
         background-color: var(
           --jh-card-color-background,
           var(--jh-color-container-primary-enabled)

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -741,7 +741,7 @@
         },
         {
           "name": "--jh-card-border-radius",
-          "description": "The card border-radius. Defaults to `--jh-border-radius-400`."
+          "description": "The card border-radius. Defaults to `--jh-border-radius-200`."
         },
         {
           "name": "--jh-card-shadow",

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -744,7 +744,7 @@
           "description": "The card border-radius. Defaults to `--jh-border-radius-200`."
         },
         {
-          "name": "--jh-card-border-color",
+          "name": "--jh-card-color-border",
           "description": "The card border color. Defaults to `--jh-border-decorative-color`."
         },
         {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -744,8 +744,8 @@
           "description": "The card border-radius. Defaults to `--jh-border-radius-200`."
         },
         {
-          "name": "--jh-card-shadow",
-          "description": "The card box-shadow. Defaults to `--jh-shadow-low`."
+          "name": "--jh-card-border-color",
+          "description": "The card border color. Defaults to `--jh-border-decorative-color`."
         },
         {
           "name": "--jh-card-media-aspect-ratio",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

 Changes to the Card component styles, including: 
- Removal of box-shadow styling.
- Addition of border (color, style, and width) styles.
- Addition of `--jh-card-border-color` styling hook. 
- Updates the border-radius default value from `--jh-border-radius-400` to  `--jh-border-radius-200`. 

**Idea number or other reference :**  219 and 317

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [X] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

N/A

