### PR TITLE
Updates next branch migration docs

### DIFF
--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -471,6 +471,9 @@ The `placeholder` property has been deprecated due to accessibility concerns. Pl
 ## Migrating jh-switch
 The default width of `jh-switch` has been reduced from 56px to 48px. Users should audit existing implementations to ensure horizontal alignment and spacing remain consistent within their layouts.
 
+## Migrating jh-card
+The border-radius of `jh-card` has been reduced from 16px to 8px. The box-shadow property has been removed in favor of a flat aesthetic and to ensure component accessibility in forced-colors mode. The `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
+
 ## Migrating jh-icons
 
 The following icon has been renamed. Please update all instances in your codebase.

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -348,11 +348,20 @@ import '@jack-henry/jh-ui/components/divider/divider.js';
 // NEW
 import '@jack-henry/jh-elements/components/divider/divider.js';
 ```
+### Migrating jh-badge
+The background color of `jh-badge` has been changed from `--jh-color-content-brand-enabled` to `--jh-color-content-negative-enabled`. font family, weight, size and line height tokens have changed from `--jh-font-helper-medium-...` to `--jh-font-helper-bold-...`.
+The `max-count` property is now set to `99` by default. 
 
-## Migrating jh-input 
+### Migrating jh-card
+The border-radius of `jh-card` has been reduced from 16px to 8px. The box-shadow property has been removed in favor of a flat aesthetic and to ensure component accessibility in forced-colors mode. The `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
+
+### Migrating jh-checkbox
+The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
+
+### Migrating jh-input 
 The jh-input component has been refactored into a base class to increase flexibility and reduce API overhead. This change introduces several breaking changes to properties and styling hooks.
 
-### New Discrete Components
+#### New Discrete Components
 The `type` property is no longer supported on the `jh-input`. You must now use specialized components or extend the base class.
 
 1. Discrete Components - replace `<jh-input type="..."` with the corresponding component below:
@@ -397,10 +406,10 @@ The `type` property is no longer supported on the `jh-input`. You must now use s
 
 2. Extend the `jh-input` Component. To create a specialized input type, refer to the [Extending Components Guide](/docs/guides-extending-components--docs) for information on how to extend components. 
 
-### Deprecated Properties
+#### Deprecated Properties
 The `placeholder` property has been deprecated due to accessibility concerns. Please leverage the `helper-text` and `label` properties to provide clear, persistent guidance for users. 
 
-### Deprecated jh-input styling hooks
+#### Deprecated jh-input styling hooks
 
 <table>
   <thead>
@@ -468,19 +477,13 @@ The `placeholder` property has been deprecated due to accessibility concerns. Pl
 * The remaining styling hooks targeting the input **field** have been renamed from `jh-input-*` to `jh-input-field-*`. **Note**: this does not apply to tokens targeting the clear button i.e. `jh-input-clear-*`. 
 * `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
-## Migrating jh-switch
+### Migrating jh-radio
+The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
+
+### Migrating jh-switch
 The default width of `jh-switch` has been reduced from 56px to 48px. Users should audit existing implementations to ensure horizontal alignment and spacing remain consistent within their layouts.
 
 The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.  
-
-## Migrating jh-radio
-The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
-
-## Migrating jh-checkbox
-The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
-
-## Migrating jh-card
-The border-radius of `jh-card` has been reduced from 16px to 8px. The box-shadow property has been removed in favor of a flat aesthetic and to ensure component accessibility in forced-colors mode. The `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
 
 ## Migrating jh-icons
 

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -238,25 +238,6 @@ The following color families have been removed:
   </tbody>
 </table>
 
-<table>
-  <thead>
-    <tr>
-      <th>Deprecated Token</th>
-      <th>New Token</th>
-    </tr>
-  </thead>
-  <tbody>
-    <tr>
-      <td>--jh-color-gray-0</td>
-      <td>--jh-color-white-alpha-100</td>
-    </tr>
-    <tr>
-      <td>--jh-color-gray-1000</td>
-      <td>--jh-color-black-alpha-100</td>
-    </tr>
-  </tbody>
-</table>
-
 ### Deprecated Shadow & Overlay Tokens
 
 <table>

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -471,6 +471,14 @@ The `placeholder` property has been deprecated due to accessibility concerns. Pl
 ## Migrating jh-switch
 The default width of `jh-switch` has been reduced from 56px to 48px. Users should audit existing implementations to ensure horizontal alignment and spacing remain consistent within their layouts.
 
+The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.  
+
+## Migrating jh-radio
+The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
+
+## Migrating jh-checkbox
+The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.
+
 ## Migrating jh-card
 The border-radius of `jh-card` has been reduced from 16px to 8px. The box-shadow property has been removed in favor of a flat aesthetic and to ensure component accessibility in forced-colors mode. The `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
 

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -381,9 +381,15 @@ In version 1, the text in `jh-list-item` and `jh-tag` would atuomatically trunca
 This behavior was removed due to accessibility and design concerns. The text in `jh-list-item` does now wrap to a new line, while `jh-tag` will expand to contain the full text.
 
 ### jh-switch
-The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element.
+The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element. The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
 
-## jh-card
+### jh-radio
+The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`.
+
+### jh-checkbox
+The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
+
+### jh-card
 The border-radius of `jh-card` has been reduced from 16px to 8px, the `box-shadow` property has been removed, and the `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
 
 ### Keyboard focus styles moved to outline

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -328,6 +328,19 @@ Refer to the Migrating page for the mapping of old to new shadow and overlay tok
 
 ## jh-elements
 
+### jh-badge
+The background color of `jh-badge` has been changed from `--jh-color-content-brand-enabled` to `--jh-color-content-negative-enabled`. font family, weight, size and line height tokens have changed from `--jh-font-helper-medium-...` to `--jh-font-helper-bold-...`.
+The `max-count` property is now set to `99` by default. 
+
+### jh-card
+The border-radius of `jh-card` has been reduced from 16px to 8px, the `box-shadow` property has been removed, and the `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
+
+### jh-checkbox
+The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
+
+### jh-checkbox-group
+The `jh-checkbox-group` now supports a `disabled` property that disables the group itself and the `jh-checkbox` components within it.
+
 ### jh-input
 
 In version 1, the design system offered a single input component (jh-input) that supported multiple specialized types, including text, search, email, password, tel, url, and textarea. This approach led to scalability and maintainability issues due to the complexity of managing all unique properties and logic within a single component.
@@ -380,17 +393,11 @@ A detailed list of [jh-input deprecated styling hooks](/docs/what-s-new-migratin
 In version 1, the text in `jh-list-item` and `jh-tag` would atuomatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
 This behavior was removed due to accessibility and design concerns. The text in `jh-list-item` does now wrap to a new line, while `jh-tag` will expand to contain the full text.
 
-### jh-switch
-The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element. The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
-
 ### jh-radio
 The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`.
 
-### jh-checkbox
-The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
-
-### jh-card
-The border-radius of `jh-card` has been reduced from 16px to 8px, the `box-shadow` property has been removed, and the `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
+### jh-switch
+The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element. The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`. 
 
 ### Keyboard focus styles moved to outline
 

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -383,6 +383,9 @@ This behavior was removed due to accessibility and design concerns. The text in 
 ### jh-switch
 The width of `jh-switch` has been updated to 48px from 56px(as present in V1). And the `box-shadow` property has been removed from the internal thumb element.
 
+## jh-card
+The border-radius of `jh-card` has been reduced from 16px to 8px, the `box-shadow` property has been removed, and the `--jh-card-color-border` styling hook has been introduced to allow for easy customization of the border color.
+
 ### Keyboard focus styles moved to outline
 
 In v1, the focus styles for interactive components were implemented using a `box-shadow` to create a focus ring around the component.


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the migration docs by:

- Removing the duplicate deprecated color tokens table.
- Adding `switch`, `radio`, and `checkbox` label typography changes.
- Adding `card` border-radius, box-shadow, and color border styling hook changes. 
- Adding `badge` typography changes, background color change, and setting max-count property default to `99`. 
- Adding `disabled` state to `jh-checkbox-group`. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a
## Notes/Dependencies

PR will remain open until sprint is complete in order to capture all changes. 

