### PR TITLE
[Badge] Update styles and add max-count default 99

### DIFF
--- a/packages/jh-elements/components/badge/badge.js
+++ b/packages/jh-elements/components/badge/badge.js
@@ -7,8 +7,8 @@ import { ifDefined } from 'lit/directives/if-defined.js';
 
 /**
  * @cssprop --jh-badge-border-radius - The badge border radius. Defaults to `--jh-border-radius-pill`.
- * @cssprop --jh-badge-color-background-enabled - The badge background color. Defaults to `--jh-color-content-brand-enabled`. 
- * @cssprop --jh-badge-color-text-enabled - The badge text color. Defaults to `--jh-color-content-on-brand-enabled`.
+ * @cssprop --jh-badge-color-background-enabled - The badge background color. Defaults to `--jh-color-content-negative-enabled`. 
+ * @cssprop --jh-badge-color-text-enabled - The badge text color. Defaults to `--jh-color-content-on-negative-enabled`.
  * 
  * @customElement jh-badge
  */
@@ -19,8 +19,8 @@ export class JhBadge extends LitElement {
       display: inline-flex;
     }
     span {
-      background: var(--jh-badge-color-background-enabled, var(--jh-color-content-brand-enabled));
-      color: var(--jh-badge-color-text-enabled, var(--jh-color-content-on-brand-enabled));
+      background: var(--jh-badge-color-background-enabled, var(--jh-color-content-negative-enabled));
+      color: var(--jh-badge-color-text-enabled, var(--jh-color-content-on-negative-enabled));
       border-radius: var(--jh-badge-border-radius, var(--jh-border-radius-pill));
       min-width: var(--jh-dimension-200);
       height: var(--jh-dimension-200);
@@ -28,10 +28,10 @@ export class JhBadge extends LitElement {
       justify-content: center;
     }
     .count-present {
-      font-family: var(--jh-font-helper-medium-font-family);
-      font-weight: var(--jh-font-helper-medium-font-weight);
-      font-size: var(--jh-font-helper-medium-font-size);
-      line-height: var(--jh-font-helper-medium-line-height);
+      font-family: var(--jh-font-helper-bold-font-family);
+      font-weight: var(--jh-font-helper-bold-font-weight);
+      font-size: var(--jh-font-helper-bold-font-size);
+      line-height: var(--jh-font-helper-bold-line-height);
       height: var(--jh-dimension-400);
       padding: var(--jh-dimension-0) var(--jh-dimension-100);
       width: auto;
@@ -44,7 +44,7 @@ export class JhBadge extends LitElement {
       /** Number to show within the badge. If no `count` is supplied, Badge will render as a dot.*/
       count: { type: String },
       /** Sets the max count to show. Appends `+` to the `max-count` when value is exceeded. */
-      maxCount: { type: String, attribute: 'max-count' },
+      maxCount: { type: Number, attribute: 'max-count' },
     };
   }
 
@@ -53,7 +53,7 @@ export class JhBadge extends LitElement {
     /** @type {?string} */
     this.count = null;
     /** @type {?number} */
-    this.maxCount = null;
+    this.maxCount = 99;
   }
 
   render() {

--- a/packages/jh-elements/components/badge/badge.stories.js
+++ b/packages/jh-elements/components/badge/badge.stories.js
@@ -41,7 +41,7 @@ export const Overview = {
     <div class="overview-row">
       <jh-badge></jh-badge>
       <jh-badge count="50"></jh-badge>
-      <jh-badge count="100" max-count="99"></jh-badge>
+      <jh-badge count="100"></jh-badge>
     </div>
   `
 };

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -13,7 +13,8 @@
         {
           "name": "max-count",
           "description": "Sets the max count to show. Appends `+` to the `max-count` when value is exceeded.",
-          "type": "?number"
+          "type": "?number",
+          "default": "99"
         }
       ],
       "properties": [
@@ -27,7 +28,8 @@
           "name": "maxCount",
           "attribute": "max-count",
           "description": "Sets the max count to show. Appends `+` to the `max-count` when value is exceeded.",
-          "type": "?number"
+          "type": "?number",
+          "default": "99"
         }
       ],
       "cssProperties": [
@@ -37,11 +39,11 @@
         },
         {
           "name": "--jh-badge-color-background-enabled",
-          "description": "The badge background color. Defaults to `--jh-color-content-brand-enabled`."
+          "description": "The badge background color. Defaults to `--jh-color-content-negative-enabled`."
         },
         {
           "name": "--jh-badge-color-text-enabled",
-          "description": "The badge text color. Defaults to `--jh-color-content-on-brand-enabled`."
+          "description": "The badge text color. Defaults to `--jh-color-content-on-negative-enabled`."
         }
       ]
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- It updates the color and the font styles to the new requirements.
- It sets the `max-count` property to 99 by default.
- It also updates the Overview story by not setting the max-count to check that the default works.
- It fixes a bug where max-count was set as String instead of Number in the properties.

**Idea number or other reference : 208

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [X] Review tokens
- [ ] Review icons
- [ ] Run script(s):
- [ ] Other (add details below)

## Notes/Dependencies
N/A



