### PR TITLE
[Tooltip] Adds helper text property

### DIFF
--- a/packages/jh-elements/components/tooltip/tooltip.js
+++ b/packages/jh-elements/components/tooltip/tooltip.js
@@ -211,13 +211,13 @@ export class JhTooltip extends LitElement {
         attribute: 'flip-disabled',
       },
       /**
-       * Provides information about the item which triggered the tooltip.
+       * Describes the item which triggered the tooltip.
        */
       label: {
         type: String,
       },
       /**
-       * Provides additional information about the item which triggered the tooltip.
+       * Provides additional context or guidance about the item that triggered the tooltip.
        */
       helperText: {
         type: String,

--- a/packages/jh-elements/components/tooltip/tooltip.js
+++ b/packages/jh-elements/components/tooltip/tooltip.js
@@ -3,7 +3,6 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import { LitElement, css, html } from 'lit';
-import { ifDefined } from 'lit/directives/if-defined.js';
 
 let id = 0;
 const openAttr = 'open';
@@ -11,6 +10,7 @@ const openAttr = 'open';
 /**
  * @cssprop --jh-tooltip-color-background - The tooltip and arrow background-color. Defaults to `--jh-color-content-primary-enabled`.
  * @cssprop --jh-tooltip-color-text - The tooltip text color. Defaults to `--jh-color-content-on-primary-enabled`.
+ * @cssprop --jh-tooltip-helper-color-text - The tooltip helper text color. Defaults to `--jh-color-content-on-primary-enabled`.
  *
  * @slot default - Use to insert the element that triggers the tooltip.
  *
@@ -26,33 +26,26 @@ export class JhTooltip extends LitElement {
         display: inline-block;
         position: relative;
       }
-      :host span {
+      .tooltip {
         background-color: var(
           --jh-tooltip-color-background,
           var(--jh-color-content-primary-enabled)
         );
-        color: var(
-          --jh-tooltip-color-text,
-          var(--jh-color-content-on-primary-enabled)
-        );
         border-radius: var(--jh-border-radius-100);
         padding: var(--jh-dimension-200);
-        font-family: var(--jh-font-helper-regular-font-family);
-        font-weight: var(--jh-font-helper-regular-font-weight);
-        font-size: var(--jh-font-helper-regular-font-size);
-        line-height: var(--jh-font-helper-regular-line-height);
         max-width: 160px;
         width: max-content;
         position: absolute;
         box-sizing: border-box;
         z-index: 1061;
         word-wrap: break-word;
-        display: inline-block;
+        display: inline-flex;
+        flex-direction: column;
         transition: visibility cubic-bezier(0.1, 0.5, 0.1, 1) 0.09s;
         visibility: hidden;
         opacity: 0;
       }
-      span::before {
+      .tooltip::before {
         position: absolute;
         z-index: 1060;
         width: 0;
@@ -61,12 +54,25 @@ export class JhTooltip extends LitElement {
         content: '';
         border: 4px solid transparent;
       }
-      :host span.show {
+      :host .tooltip.show {
         transition: opacity 0.3s cubic-bezier(0.1, 0.5, 0.1, 1) 0s;
         visibility: visible;
         opacity: 1;
       }
-
+      .label {
+        color: var(--jh-tooltip-color-text, var(--jh-color-content-on-primary-enabled));
+        font-family: var(--jh-font-helper-regular-font-family);
+        font-weight: var(--jh-font-helper-regular-font-weight);
+        font-size: var(--jh-font-helper-regular-font-size);
+        line-height: var(--jh-font-helper-regular-line-height);
+      }
+      .helper-text {
+        color: var(--jh-tooltip-helper-color-text, var(--jh-color-content-on-primary-enabled));
+        font-family: var(--jh-font-micro-regular-font-family);
+        font-weight: var(--jh-font-micro-regular-font-weight);
+        font-size: var(--jh-font-micro-regular-font-size);
+        line-height: var(--jh-font-micro-regular-line-height);
+      }
       /* padding and margin used to extend hover surface for tooltip persistence */
       :host([position='bottom-center']),
       :host([position='bottom-start']),
@@ -90,15 +96,15 @@ export class JhTooltip extends LitElement {
       }
 
       /* placement of tooltip and arrow. Default is top-center */
-      :host([position='bottom-center']) span,
-      :host([position='bottom-start']) span,
-      :host([position='bottom-end']) span {
+      :host([position='bottom-center']) .tooltip,
+      :host([position='bottom-start']) .tooltip,
+      :host([position='bottom-end']) .tooltip {
         top: 100%;
         right: 50%;
       }
-      :host([position='bottom-center']) span::before,
-      :host([position='bottom-start']) span::before,
-      :host([position='bottom-end']) span::before {
+      :host([position='bottom-center']) .tooltip::before,
+      :host([position='bottom-start']) .tooltip::before,
+      :host([position='bottom-end']) .tooltip::before {
         border-bottom-color: var(
           --jh-tooltip-color-background,
           var(--jh-color-content-primary-enabled)
@@ -106,33 +112,33 @@ export class JhTooltip extends LitElement {
         top: auto;
         bottom: 100%;
       }
-      :host([position='bottom-center']) span::before {
+      :host([position='bottom-center']) .tooltip::before {
         margin-right: calc(var(--jh-dimension-200) * -0.5);
         right: 50%;
       }
-      :host([position='bottom-start']) span::before {
+      :host([position='bottom-start']) .tooltip::before {
         left: var(--jh-dimension-200);
       }
-      :host([position='bottom-end']) span::before {
+      :host([position='bottom-end']) .tooltip::before {
         right: var(--jh-dimension-200);
       }
-      :host([position='bottom-start']) span {
+      :host([position='bottom-start']) .tooltip {
         margin-left: calc(var(--jh-dimension-200) * -1.5);
         right: auto;
         left: 50%;
       }
-      :host([position='bottom-end']) span {
+      :host([position='bottom-end']) .tooltip {
         margin-right: calc(var(--jh-dimension-200) * -1.5);
       }
-      :host([position='top-center']) span,
-      :host([position='top-start']) span,
-      :host([position='top-end']) span {
+      :host([position='top-center']) .tooltip,
+      :host([position='top-start']) .tooltip,
+      :host([position='top-end']) .tooltip {
         right: 50%;
         bottom: 100%;
       }
-      :host([position='top-center']) span::before,
-      :host([position='top-start']) span::before,
-      :host([position='top-end']) span::before {
+      :host([position='top-center']) .tooltip::before,
+      :host([position='top-start']) .tooltip::before,
+      :host([position='top-end']) .tooltip::before {
         border-top-color: var(
           --jh-tooltip-color-background,
           var(--jh-color-content-primary-enabled)
@@ -140,34 +146,34 @@ export class JhTooltip extends LitElement {
         top: 100%;
         bottom: auto;
       }
-      :host([position='top-center']) span::before {
+      :host([position='top-center']) .tooltip::before {
         margin-right: calc(var(--jh-dimension-200) * -0.5);
         right: 50%;
       }
-      :host([position='top-start']) span::before {
+      :host([position='top-start']) .tooltip::before {
         left: var(--jh-dimension-200);
       }
-      :host([position='top-end']) span::before {
+      :host([position='top-end']) .tooltip::before {
         right: var(--jh-dimension-200);
       }
-      :host([position='top-start']) span {
+      :host([position='top-start']) .tooltip {
         margin-left: calc(var(--jh-dimension-200) * -1.5);
         right: auto;
         left: 50%;
       }
-      :host([position='top-end']) span {
+      :host([position='top-end']) .tooltip {
         margin-right: calc(var(--jh-dimension-200) * -1.5);
       }
-      :host([position='bottom-center']) span,
-      :host([position='top-center']) span {
+      :host([position='bottom-center']) .tooltip,
+      :host([position='top-center']) .tooltip {
         transform: translateX(50%);
       }
-      :host([position='left']) span {
+      :host([position='left']) .tooltip {
         right: 100%;
         bottom: 50%;
         transform: translateY(50%);
       }
-      :host([position='left']) span::before {
+      :host([position='left']) .tooltip::before {
         border-left-color: var(
           --jh-tooltip-color-background,
           var(--jh-color-content-primary-enabled)
@@ -177,12 +183,12 @@ export class JhTooltip extends LitElement {
         bottom: 50%;
         left: 100%;
       }
-      :host([position='right']) span {
+      :host([position='right']) .tooltip {
         bottom: 50%;
         left: 100%;
         transform: translateY(50%);
       }
-      :host([position='right']) span::before {
+      :host([position='right']) .tooltip::before {
         border-right-color: var(
           --jh-tooltip-color-background,
           var(--jh-color-content-primary-enabled)
@@ -211,6 +217,13 @@ export class JhTooltip extends LitElement {
         type: String,
       },
       /**
+       * Provides additional information about the item which triggered the tooltip.
+       */
+      helperText: {
+        type: String,
+        attribute: 'helper-text',
+      },
+      /**
        * Determines whether the tooltip is open or closed. Can be set on the tooltip to force it open.
        */
       open: {
@@ -234,6 +247,8 @@ export class JhTooltip extends LitElement {
     this.flipDisabled = false;
     /** @type {?string} */
     this.label = null;
+    /** @type {?string} */
+    this.helperText = null;
     /**@type {?Boolean} */
     this.open = false;
     /** @type {?string} */
@@ -254,12 +269,12 @@ export class JhTooltip extends LitElement {
   #handleEmptyLabel(mutations) {
     for (let mutation of mutations) {
       const addedNodes = Array.from(mutation.addedNodes);
-      //check if any of the added nodes is a span
-      const spanAdded = addedNodes.some(
-        (addedNode) => addedNode.tagName === 'SPAN'
+      //check if any of the added nodes is a div
+      const divAdded = addedNodes.some(
+        (addedNode) => addedNode.tagName === 'DIV'
       );
 
-      if (spanAdded) {
+      if (divAdded) {
         this.#internals.role = 'tooltip';
         this.addEventListener('focus', this.#handleOpenTooltip, true);
         this.addEventListener('mouseenter', this.#handleOpenTooltip);
@@ -299,9 +314,19 @@ export class JhTooltip extends LitElement {
   }
 
   //calls flipTooltip whenever the tooltip is updated, including manually opened with 'open' property.
-  updated() {
-    if (this.open) this.#flipTooltip();
+updated(changedProperties) {
+  if (
+    this.open &&
+    (changedProperties.has('open') ||
+      changedProperties.has('label') ||
+      changedProperties.has('helperText') ||
+      changedProperties.has('position'))
+  ) {
+    requestAnimationFrame(() => {
+      this.#flipTooltip();
+    });
   }
+}
 
   #handleKeyDown(e) {
     if (e.key === 'Escape') this.#handleCloseTooltip();
@@ -323,7 +348,7 @@ export class JhTooltip extends LitElement {
     //check if current position is a valid position otherwise make it fail.
     if (!['left', 'right', 'top-start', 'top-end', 'top-center', 'bottom-start', 'bottom-end', 'bottom-center'].includes(currentPosition)) return;
     
-    if (this.flipDisabled === false && this.label) {
+    if (this.flipDisabled === false && (this.label || this.helperText)) {
      
       //break current position into tooltop position and arrow position
       const [currentTooltip, currentArrow] = currentPosition.split('-');
@@ -450,10 +475,10 @@ export class JhTooltip extends LitElement {
   #getDimensions() {
     return {
       tooltipWidth: this.shadowRoot
-        .querySelector('span')
+        .querySelector('.tooltip')
         .getBoundingClientRect().width,
       tooltipHeight: this.shadowRoot
-        .querySelector('span')
+        .querySelector('.tooltip')
         .getBoundingClientRect().height,
       elemHeight: this.getBoundingClientRect().height,
       elemWidth: this.getBoundingClientRect().width,
@@ -475,22 +500,23 @@ export class JhTooltip extends LitElement {
   }
 
   render() {
-    let label;
+    let tooltip;
 
-    if (this.label) {
-      label = html`
-        <span
-          class=${ifDefined(this.open ? 'show' : null)}
+    if (this.label || this.helperText) {
+      tooltip = html`
+        <div
+          class=${this.open ? 'tooltip show' : 'tooltip'}
           aria-hidden=${this.open ? 'false' : 'true'}
         >
-          ${this.label}
-        </span>
+          ${this.label ? html`<div class="label">${this.label}</div>` : ''}
+          ${this.helperText ? html`<div class="helper-text">${this.helperText}</div>` : ''}
+    </div>
       `;
     }
 
     return html`
       <slot @slotchange=${this.#handleSlotChange}></slot>
-      ${label}
+      ${tooltip}
     `;
   }
 }

--- a/packages/jh-elements/components/tooltip/tooltip.stories.js
+++ b/packages/jh-elements/components/tooltip/tooltip.stories.js
@@ -6,6 +6,7 @@ import { html, css } from 'lit';
 import './tooltip.js';
 import '../button/button.js';
 import '@jack-henry/jh-icons/icons-wc/icon-ellipsis.js';
+import { ifDefined } from 'lit/directives/if-defined.js';
 
 const storyStyles = css`
   .flipping-tooltip {
@@ -19,7 +20,7 @@ const storyStyles = css`
     justify-items: center;
     width: 100%;
     margin-bottom: 50px;
-    margin-top: 30px;
+    margin-top: 60px;
     margin-left: 30px;
   }
   .overviewSides {
@@ -32,7 +33,7 @@ const storyStyles = css`
   .center {
     display: flex;
     justify-content: center;
-    height: 100px;
+    height: 150px;
     align-items: center;
     width: 100%;
   }
@@ -43,6 +44,7 @@ const disabledControls = {
   position: { control: { disable: true } },
   open: { control: { disable: true } },
   'flip-disabled': { control: { disable: true } },
+  'helper-text': { control: { disable: true } },
 };
 
 export default {
@@ -67,6 +69,11 @@ export default {
         type: 'text',
       },
     },
+    'helper-text': {
+      control: {
+        type: 'text',
+      },
+    },
     open: {
       control: {
         type: 'boolean',
@@ -84,19 +91,19 @@ export const Overview = {
   render: (args) =>
     html`<div class="overview">
       <div>
-        <jh-tooltip label="top-start" position="top-start"
+        <jh-tooltip label="top-start" helper-text="helper text" position="top-start"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="top-center" position="top-center"
+        <jh-tooltip label="top-center" helper-text="helper text" position="top-center"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="top-end" position="top-end"
+        <jh-tooltip label="top-end" helper-text="helper text" position="top-end"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
@@ -104,13 +111,13 @@ export const Overview = {
         ></jh-tooltip>
       </div>
       <div class="overviewSides">
-        <jh-tooltip label="left" position="left"
+        <jh-tooltip label="left" helper-text="helper text" position="left"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="right" position="right"
+        <jh-tooltip label="right" helper-text="helper text" position="right"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
@@ -118,19 +125,19 @@ export const Overview = {
         ></jh-tooltip>
       </div>
       <div>
-        <jh-tooltip label="bottom-start" position="bottom-start"
+        <jh-tooltip label="bottom-start" helper-text="helper text" position="bottom-start"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="bottom-center" position="bottom-center"
+        <jh-tooltip label="bottom-center" helper-text="helper text" position="bottom-center"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="bottom-end" position="bottom-end"
+        <jh-tooltip label="bottom-end" helper-text="helper text" position="bottom-end"
           ><jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
@@ -150,7 +157,8 @@ export const Playground = {
   render: (args) =>
     html` <div class="center">
       <jh-tooltip
-        label=${args.label}
+        label=${ifDefined(args.label)}
+        helper-text=${ifDefined(args['helper-text'])}
         position=${args.position}
         ?open=${args.open}
         ?flip-disabled=${args['flip-disabled']}
@@ -164,6 +172,7 @@ Playground.args = {
   position: 'top-center',
   open: false,
   'flip-disabled': false,
+  'helper-text': 'A long string of helper text to test the wrapping.',
 };
 Playground.parameters = {
   styles: storyStyles,
@@ -173,7 +182,7 @@ Playground.parameters = {
 export const Default = {
   render: (args) =>
     html` <div class="center">
-      <jh-tooltip label="top-center" position="top-center"
+      <jh-tooltip label="top-center" helper-text="helper text" position="top-center"
         ><jh-button label="Default"></jh-button
       ></jh-tooltip>
     </div>`,
@@ -191,6 +200,7 @@ export const ManuallyOpen = {
     html` <div class="center">
       <jh-tooltip
         label="Open Tooltip"
+        helper-text="helper text"
         position=${args.position}
         ?open=${args.open}
         ><jh-button label="Open"></jh-button
@@ -207,6 +217,7 @@ ManuallyOpen.parameters = {
 ManuallyOpen.argTypes = {
   label: { table: { disable: true } },
   'flip-disabled': { table: { disable: true } },
+  'helper-text': { table: { disable: true } },
 };
 
 export const FlippingTooltip = {
@@ -215,11 +226,13 @@ export const FlippingTooltip = {
       <div class="flipping-tooltip">
         <jh-tooltip
           label="I am a default tooltip that flips"
+          helper-text="helper text"
           position=${args.position}
           ><jh-button label="Flip"></jh-button
         ></jh-tooltip>
         <jh-tooltip
           label="I am a tooltip that doesn't flip"
+          helper-text="helper text"
           position=${args.position}
           flip-disabled
           ><jh-button label="No Flip"></jh-button
@@ -238,4 +251,5 @@ FlippingTooltip.argTypes = {
   label: { table: { disable: true } },
   open: { table: { disable: true } },
   'flip-disabled': { table: { disable: true } },
+  'helper-text': { table: { disable: true } },
 };

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6830,6 +6830,11 @@
           "type": "?string"
         },
         {
+          "name": "helper-text",
+          "description": "Provides additional information about the item which triggered the tooltip.",
+          "type": "?string"
+        },
+        {
           "name": "open",
           "description": "Determines whether the tooltip is open or closed. Can be set on the tooltip to force it open.",
           "type": "?Boolean",
@@ -6854,6 +6859,12 @@
           "name": "label",
           "attribute": "label",
           "description": "Provides information about the item which triggered the tooltip.",
+          "type": "?string"
+        },
+        {
+          "name": "helperText",
+          "attribute": "helper-text",
+          "description": "Provides additional information about the item which triggered the tooltip.",
           "type": "?string"
         },
         {
@@ -6885,6 +6896,10 @@
         {
           "name": "--jh-tooltip-color-text",
           "description": "The tooltip text color. Defaults to `--jh-color-content-on-primary-enabled`."
+        },
+        {
+          "name": "--jh-tooltip-helper-color-text",
+          "description": "The tooltip helper text color. Defaults to `--jh-color-content-on-primary-enabled`."
         }
       ]
     }

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6845,12 +6845,12 @@
         },
         {
           "name": "label",
-          "description": "Provides information about the item which triggered the tooltip.",
+          "description": "Describes the item which triggered the tooltip.",
           "type": "?string"
         },
         {
           "name": "helper-text",
-          "description": "Provides additional information about the item which triggered the tooltip.",
+          "description": "Provides additional context or guidance about the item that triggered the tooltip.",
           "type": "?string"
         },
         {
@@ -6877,13 +6877,13 @@
         {
           "name": "label",
           "attribute": "label",
-          "description": "Provides information about the item which triggered the tooltip.",
+          "description": "Describes the item which triggered the tooltip.",
           "type": "?string"
         },
         {
           "name": "helperText",
           "attribute": "helper-text",
-          "description": "Provides additional information about the item which triggered the tooltip.",
+          "description": "Provides additional context or guidance about the item that triggered the tooltip.",
           "type": "?string"
         },
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- It adds the `helper-text` property and related styling hook so that additional text information can be added to the tooltip. 
- It updates the tooltip flipping logic/css to handle it.
- It adds `requestAnimationFrame` to to `fupdate` to ensure that the tooltip size is calculated correctly before attempting to flip the tooltip.


**Idea number or other reference :** 186

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [X] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

I have updated the stories so they all have helper text. You can also test with only label or helper text in the Playground story.

## Notes/Dependencies

N/A


