### PR TITLE
Fixes a bug with table header z-index and one with scrollbars visibility

### DIFF
--- a/packages/jh-elements/components/table/table.js
+++ b/packages/jh-elements/components/table/table.js
@@ -180,8 +180,10 @@ export class JhTable extends LitElement {
       }
 
       :host([scrollable]) .table-container {
-        overflow: scroll;
+        overflow: auto;
         height: 100%;
+        /* keeps space reserved for vertical scrollbar */
+        scrollbar-gutter: stable;
         /* removes bouncy scroll behavior in Safari and FF */
         /* overscroll-behavior: none; */
       }
@@ -295,7 +297,6 @@ export class JhTable extends LitElement {
   async firstUpdated() {
     if (!this.scrollable) return;
 
-    const container = this.shadowRoot.querySelector('.table-container');
     let scrollTable = this.shadowRoot.querySelector('.table');
     await scrollTable.updateComplete;
     let originalTableWidth = scrollTable.getBoundingClientRect().width;

--- a/packages/jh-elements/components/table/table.js
+++ b/packages/jh-elements/components/table/table.js
@@ -132,7 +132,7 @@ export class JhTable extends LitElement {
       :host([sticky-header]) .header {
         position: sticky;
         top: 0;
-        z-index: 2000;
+        z-index: 1000;
       }
       :host([sticky-footer]) .footer {
         --jh-table-data-cell-color-border-top: var(
@@ -140,7 +140,7 @@ export class JhTable extends LitElement {
         );
         position: sticky;
         bottom: 0;
-        z-index: 2000;
+        z-index: 1000;
       }
       :host([sticky-footer]) .body::slotted(jh-table-row:nth-last-of-type(2)) {
         --jh-table-data-cell-color-border-bottom: transparent;

--- a/packages/jh-elements/components/table/table.js
+++ b/packages/jh-elements/components/table/table.js
@@ -132,6 +132,7 @@ export class JhTable extends LitElement {
       :host([sticky-header]) .header {
         position: sticky;
         top: 0;
+        z-index: 2000;
       }
       :host([sticky-footer]) .footer {
         --jh-table-data-cell-color-border-top: var(
@@ -139,6 +140,7 @@ export class JhTable extends LitElement {
         );
         position: sticky;
         bottom: 0;
+        z-index: 2000;
       }
       :host([sticky-footer]) .body::slotted(jh-table-row:nth-last-of-type(2)) {
         --jh-table-data-cell-color-border-bottom: transparent;

--- a/packages/jh-elements/components/table/table.stories.js
+++ b/packages/jh-elements/components/table/table.stories.js
@@ -9,6 +9,7 @@ import '../table-data-cell/table-data-cell.js';
 import '../table-row/table-row.js';
 import '../button/button.js';
 import '../checkbox/checkbox.js';
+import '../tooltip/tooltip.js';
 
 const storyStyles = css`
 .overview {
@@ -338,7 +339,7 @@ export const ScrollTest = { render: (args) => html`
       <jh-table-header-cell>Column 5</jh-table-header-cell>
     </jh-table-row>
     <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 1"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell><jh-tooltip label="tooltip"><jh-checkbox label="Row 1"></jh-checkbox></jh-tooltip></jh-table-data-cell>
       <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
       <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
       <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>

--- a/packages/jh-elements/components/table/table.stories.js
+++ b/packages/jh-elements/components/table/table.stories.js
@@ -7,9 +7,6 @@ import './table.js';
 import '../table-header-cell/table-header-cell.js';
 import '../table-data-cell/table-data-cell.js';
 import '../table-row/table-row.js';
-import '../button/button.js';
-import '../checkbox/checkbox.js';
-import '../tooltip/tooltip.js';
 
 const storyStyles = css`
 .overview {
@@ -21,13 +18,6 @@ const storyStyles = css`
 .scrollable {
   width: 600px;
   height: 500px;
-}
-.scrolltest {
-  /* width: 400px; */
-  height: 500px;
-}
-.scrolltest jh-table-data-cell {
-  min-width: 80px;
 }
 `;
 
@@ -325,86 +315,6 @@ export const Scrollable = { render: (args) => html`
     Scrollable.parameters = {
       styles: storyStyles,
     };
-
-export const ScrollTest = { render: (args) => html`
-<div class="scrolltest">
-  <jh-table vertical-align="top" scrollable sticky-header sticky-footer>
-    <div slot="jh-table-caption">Scroll Test Table</div>
-    <div slot="jh-table-toolbar">Toolbar</div>
-    <jh-table-row slot="jh-table-header">
-      <jh-table-header-cell><jh-checkbox label="Select all"></jh-checkbox></jh-table-header-cell>
-      <jh-table-header-cell>Column 2</jh-table-header-cell>
-      <jh-table-header-cell>Column 3</jh-table-header-cell>
-      <jh-table-header-cell>Column 4</jh-table-header-cell>
-      <jh-table-header-cell>Column 5</jh-table-header-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-tooltip label="tooltip"><jh-checkbox label="Row 1"></jh-checkbox></jh-tooltip></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 2"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 3"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 4"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 5"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 6"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row>
-      <jh-table-data-cell><jh-checkbox label="Row 7"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <jh-table-row slot="jh-table-footer">
-      <jh-table-data-cell><jh-checkbox label="Footer"></jh-checkbox></jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum dolor sit</jh-table-data-cell>
-      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-    </jh-table-row>
-    <div slot="jh-table-pagination">Pagination</div>
-  </jh-table>
-</div>
-`};
-
-ScrollTest.argTypes = {
-  ...disableControls,
-};
-ScrollTest.parameters = {
-  styles: storyStyles,
-};
 
 
 

--- a/packages/jh-elements/components/table/table.stories.js
+++ b/packages/jh-elements/components/table/table.stories.js
@@ -8,6 +8,7 @@ import '../table-header-cell/table-header-cell.js';
 import '../table-data-cell/table-data-cell.js';
 import '../table-row/table-row.js';
 import '../button/button.js';
+import '../checkbox/checkbox.js';
 
 const storyStyles = css`
 .overview {
@@ -19,6 +20,13 @@ const storyStyles = css`
 .scrollable {
   width: 600px;
   height: 500px;
+}
+.scrolltest {
+  /* width: 400px; */
+  height: 500px;
+}
+.scrolltest jh-table-data-cell {
+  min-width: 80px;
 }
 `;
 
@@ -286,7 +294,7 @@ export const Scrollable = { render: (args) => html`
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-        <jh-table-data-cell >Lorem ipsum dolor sit amet consectetur adipiscing elit</jh-table-data-cell>
+        <jh-table-data-cell >Lorem ipsum</jh-table-data-cell>
     </jh-table-row>
     <jh-table-row slot="jh-table-footer">
     <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
@@ -296,7 +304,7 @@ export const Scrollable = { render: (args) => html`
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
         <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
-        <jh-table-data-cell >Lorem ipsum dolor</jh-table-data-cell>
+        <jh-table-data-cell >Lorem ipsum dolor sit amet</jh-table-data-cell>
     </jh-table-row>
     <div slot="jh-table-pagination">Pagination</div>
     </jh-table>
@@ -316,6 +324,86 @@ export const Scrollable = { render: (args) => html`
     Scrollable.parameters = {
       styles: storyStyles,
     };
+
+export const ScrollTest = { render: (args) => html`
+<div class="scrolltest">
+  <jh-table vertical-align="top" scrollable sticky-header sticky-footer>
+    <div slot="jh-table-caption">Scroll Test Table</div>
+    <div slot="jh-table-toolbar">Toolbar</div>
+    <jh-table-row slot="jh-table-header">
+      <jh-table-header-cell><jh-checkbox label="Select all"></jh-checkbox></jh-table-header-cell>
+      <jh-table-header-cell>Column 2</jh-table-header-cell>
+      <jh-table-header-cell>Column 3</jh-table-header-cell>
+      <jh-table-header-cell>Column 4</jh-table-header-cell>
+      <jh-table-header-cell>Column 5</jh-table-header-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 1"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 2"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 3"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 4"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 5"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 6"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row>
+      <jh-table-data-cell><jh-checkbox label="Row 7"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit amet</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <jh-table-row slot="jh-table-footer">
+      <jh-table-data-cell><jh-checkbox label="Footer"></jh-checkbox></jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum dolor sit</jh-table-data-cell>
+      <jh-table-data-cell>Lorem ipsum</jh-table-data-cell>
+    </jh-table-row>
+    <div slot="jh-table-pagination">Pagination</div>
+  </jh-table>
+</div>
+`};
+
+ScrollTest.argTypes = {
+  ...disableControls,
+};
+ScrollTest.parameters = {
+  styles: storyStyles,
+};
 
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It fixes 2 bugs reported internally:
1. Items with z-index applied flow over sticky header (and footers).
2. Scrollbars are visible even when they are not needed.

**Idea number or other reference :** 

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

Review the Scroll Test story for both issues. To see the scrollbars appear and disappear, you can either resize the browser, or change the container size in the story itself.

## Notes/Dependencies

The Scroll Test story will be removed before merging.


