### PR TITLE
[input-email] Removes type email and sets inputmode to email

### DIFF
--- a/packages/jh-elements/components/input-email/input-email.js
+++ b/packages/jh-elements/components/input-email/input-email.js
@@ -11,7 +11,7 @@ import { JhInput } from '../input/input.js';
 export class JhInputEmail extends JhInput {
   constructor() {
     super();
-    this.type = 'email';
+    this.inputmode = 'email';
   }
 }
 customElements.define('jh-input-email', JhInputEmail);

--- a/packages/jh-elements/components/input-email/input-email.js
+++ b/packages/jh-elements/components/input-email/input-email.js
@@ -9,10 +9,9 @@ import { JhInput } from '../input/input.js';
  * @customElement jh-input-email
  */
 export class JhInputEmail extends JhInput {
-  firstUpdated() {
-    super.firstUpdated();
-    let inputEl = this.shadowRoot.querySelector('input');
-    inputEl.setAttribute('type', 'email');
+  constructor() {
+    super();
+    this.type = 'email';
   }
 }
 customElements.define('jh-input-email', JhInputEmail);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1386,7 +1386,8 @@
         {
           "name": "inputmode",
           "description": "Indicates expected input value type and allows for browsers to display appropriate virtual keyboard.\n\n[Visit MDN for information on supported inputmode values](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)",
-          "type": "?string"
+          "type": "?string",
+          "default": "\"email\""
         },
         {
           "name": "invalid",
@@ -1524,7 +1525,8 @@
           "name": "inputmode",
           "attribute": "inputmode",
           "description": "Indicates expected input value type and allows for browsers to display appropriate virtual keyboard.\n\n[Visit MDN for information on supported inputmode values](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/inputmode)",
-          "type": "?string"
+          "type": "?string",
+          "default": "\"email\""
         },
         {
           "name": "invalid",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Removes the `type="email"` attribute from the `jh-input-email` component as it does not support the properties (selectionStart and selectionEnd) needed for the `input-mask` to work. Sets the `inputmode` property to email to render a virtual keyboard optimized for entering email addresses. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

[HTML Specs](https://html.spec.whatwg.org/dev/input.html)

