### PR TITLE
[Checkbox Group] Updates label font from regular to medium

### DIFF
--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -30,10 +30,14 @@ export class JhCheckboxGroup extends LitElement {
   static get styles() {
     return css`
       :host {
-        font-family: var(--jh-font-helper-regular-font-family);
-        font-weight: var(--jh-font-helper-regular-font-weight);
-        font-size: var(--jh-font-helper-regular-font-size);
-        line-height: var(--jh-font-helper-regular-line-height);
+        --checkbox-group-helper-regular-font-family: var(--jh-font-helper-regular-font-family);
+        --checkbox-group-helper-regular-font-weight: var(--jh-font-helper-regular-font-weight);
+        --checkbox-group-helper-regular-font-size: var(--jh-font-helper-regular-font-size);
+        --checkbox-group-helper-regular-line-height: var(--jh-font-helper-regular-line-height);
+        font-family: var(--checkbox-group-helper-regular-font-family);
+        font-weight: var(--checkbox-group-helper-regular-font-weight);
+        font-size: var(--checkbox-group-helper-regular-font-size);
+        line-height: var(--checkbox-group-helper-regular-line-height);
         display: block;
       }
       /* reset fieldset and legend for styling */
@@ -119,6 +123,10 @@ export class JhCheckboxGroup extends LitElement {
           --jh-checkbox-group-required-color-text-optional,
           var(--jh-color-content-primary-enabled)
         );
+        font-family: var(--checkbox-group-helper-regular-font-family);
+        font-weight: var(--checkbox-group-helper-regular-font-weight);
+        font-size: var(--checkbox-group-helper-regular-font-size);
+        line-height: var(--checkbox-group-helper-regular-line-height);
       }
       :host([show-indicator][required]) .indicator {
         color: var(

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -91,6 +91,10 @@ export class JhCheckboxGroup extends LitElement {
           --jh-checkbox-group-label-color-text,
           var(--jh-color-content-primary-enabled)
         );
+        font-family: var(--jh-font-helper-medium-font-family);
+        font-weight: var(--jh-font-helper-medium-font-weight);
+        font-size: var(--jh-font-helper-medium-font-size);
+        line-height: var(--jh-font-helper-medium-line-height);
       }
       .helper-text {
         color: var(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the checkbox-group label to use the `--jh-font-helper-medium` tokens to ensure consistency across form controls.

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [X] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a




