### PR TITLE
[Tokens] Add color-scheme changes and regenerate tokens

### DIFF
--- a/packages/jh-elements/docs/getting-started/usage.mdx
+++ b/packages/jh-elements/docs/getting-started/usage.mdx
@@ -47,6 +47,8 @@ setJhTheme();
 
 This will place both light and dark themed design system CSS custom properties at the top of the document head within two separate style tags named `id="jh-theme-light”` and `id="jh-theme-dark”`. The light theme is scoped to `:root` and will automatically be applied to all components. Whereas the dark theme is scoped to `.jh-theme-dark` and will require `class="jh-theme-dark”` to be added at the top of your application in order to be applied. 
 
+We have included the appropriate `color-scheme: light` or `color-scheme: dark` declarations in our theme files. This instructs browsers to apply native styling that matches the selected theme to browser-rendered elements like form controls, scrollbars, and selection highlights, providing a consistent visual experience without additional styling effort.
+
 Additionally, you can provide specific custom property overrides by appending your own style tag to the document head *below* the design system themes. This ensures that as the stylesheets cascade, your custom property will successfully override that defined by the design system. 
 
 ## Using styling hooks

--- a/packages/jh-tokens/lib/build.js
+++ b/packages/jh-tokens/lib/build.js
@@ -3,7 +3,8 @@
 // SPDX-License-Identifier: Apache-2.0
 
 import StyleDictionary from 'style-dictionary';
-import formatJs from './formats/format.js';
+import formatJs from './formats/esm-format.js';
+import formatCss from './formats/css-format.js';
 import formatDocs from './formats/json-flat.js';
 
 function getStyleDictionary(theme, platform) {
@@ -30,6 +31,7 @@ function getStyleDictionary(theme, platform) {
       },
       formats: {
         'custom/format/esm': formatJs,
+        'custom/format/css': formatCss,
         'custom/format/json': formatDocs,
       },
     },
@@ -46,7 +48,7 @@ function getStyleDictionary(theme, platform) {
         files: [
           {
             destination: `css/jh-theme-${theme}.css`,
-            format: 'css/variables',
+            format: 'custom/format/css',
             options: {
               // if file should keep output references: ie --color-danger: var(--color-red); vs --color-danger: #ff0000;
               outputReferences: true,
@@ -62,6 +64,7 @@ function getStyleDictionary(theme, platform) {
               usesDtcg: true,
               fileHeader: 'licensedFileHeader',
               selector: `${theme === 'light' ? ':root' : `.jh-theme-${theme}`}`,
+              showColorScheme: true
             },
           },
         ],

--- a/packages/jh-tokens/lib/formats/css-format.js
+++ b/packages/jh-tokens/lib/formats/css-format.js
@@ -1,0 +1,27 @@
+// SPDX-FileCopyrightText: 2026 Jack Henry
+//
+// SPDX-License-Identifier: Apache-2.0
+
+import { fileHeader, formattedVariables } from 'style-dictionary/utils';
+
+async function FormatCss({ dictionary, file, options }) {
+    const { outputReferences, usesDtcg } = options;
+    const header = await fileHeader({ file });
+    // Determine the value of color-scheme property based on the theme.
+    const isDark = options.selector.includes('dark');
+    const colorSchemeValue = isDark ? 'dark': 'light';
+
+    return (
+      header +
+      `${options.selector} {\n` +
+      `  color-scheme: ${colorSchemeValue};\n` +
+      formattedVariables({
+        format: 'css',
+        dictionary,
+        outputReferences, usesDtcg
+      }) +
+      '\n}\n'
+    );
+  }
+
+export default FormatCss;

--- a/packages/jh-tokens/lib/formats/esm-format.js
+++ b/packages/jh-tokens/lib/formats/esm-format.js
@@ -6,7 +6,7 @@ import { fileHeader, formattedVariables } from 'style-dictionary/utils';
 
 //will need to remove $description from the output in DTCG version
 async function formatJs({ dictionary, file, options }) {
-  const { outputReferences, usesDtcg } = options;
+  const { outputReferences, usesDtcg, showColorScheme } = options;
   const header = await fileHeader({ file });
   function indent2(str) {
     // removes whitespace fom the end of a string with the matched substring & adds indentation to each line
@@ -16,7 +16,11 @@ async function formatJs({ dictionary, file, options }) {
     header +
     'export default `\n  ' +
     options.selector +
-    ' {\n' +
+    (showColorScheme
+      ? options.selector === '.jh-theme-dark'
+        ? ' {\n    color-scheme: dark; \n'
+        : ' {\n    color-scheme: light; \n' 
+      : ' {\n') +
     indent2(
       formattedVariables({ format: 'css', dictionary, outputReferences, usesDtcg })
     ) +

--- a/packages/jh-tokens/platforms/web/css/jh-theme-dark.css
+++ b/packages/jh-tokens/platforms/web/css/jh-theme-dark.css
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 12 Nov 2025 19:24:22 GMT
+ * Generated on Tue, 07 Apr 2026 18:56:06 GMT
  */
 
 .jh-theme-dark {
+  color-scheme: dark;
   --jh-z-index-positive-1000: 1000;
   --jh-z-index-positive-900: 900;
   --jh-z-index-positive-800: 800;

--- a/packages/jh-tokens/platforms/web/css/jh-theme-light.css
+++ b/packages/jh-tokens/platforms/web/css/jh-theme-light.css
@@ -4,10 +4,11 @@
  * SPDX-License-Identifier: Apache-2.0
  * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 12 Nov 2025 19:24:22 GMT
+ * Generated on Tue, 07 Apr 2026 18:56:06 GMT
  */
 
 :root {
+  color-scheme: light;
   --jh-z-index-positive-1000: 1000;
   --jh-z-index-positive-900: 900;
   --jh-z-index-positive-800: 800;

--- a/packages/jh-tokens/platforms/web/esm/jh-theme-dark.js
+++ b/packages/jh-tokens/platforms/web/esm/jh-theme-dark.js
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 12 Nov 2025 19:24:22 GMT
+ * Generated on Tue, 07 Apr 2026 18:56:06 GMT
  */
 
 export default `
   .jh-theme-dark {
+    color-scheme: dark; 
     --jh-z-index-positive-1000: 1000;
     --jh-z-index-positive-900: 900;
     --jh-z-index-positive-800: 800;

--- a/packages/jh-tokens/platforms/web/esm/jh-theme-light.js
+++ b/packages/jh-tokens/platforms/web/esm/jh-theme-light.js
@@ -4,11 +4,12 @@
  * SPDX-License-Identifier: Apache-2.0
  * 
  * Do not edit directly, this file was auto-generated.
- * Generated on Wed, 12 Nov 2025 19:24:22 GMT
+ * Generated on Tue, 07 Apr 2026 18:56:06 GMT
  */
 
 export default `
   :root {
+    color-scheme: light; 
     --jh-z-index-positive-1000: 1000;
     --jh-z-index-positive-900: 900;
     --jh-z-index-positive-800: 800;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- It modifies the Style Dictionary formats so that `color-scheme: dark` and `color-scheme: light` are automatically added to our esm and css token files.
- This is needed to ensure that the browser represents items like scrollbars in the correct color scheme.

**Idea number or other reference :** [related to the menu scrollbars PR]

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [X] Review tokens
- [ ] Review icons
- [X] Run script(s): `pnpm build:jh-tokens`
- [ ] Other (add details below)

**Additional Details**

When you run the token build step, you should see the `color-scheme` added at the top (and the date change), no other changes.

## Notes/Dependencies

- This PR is related to the PR adding scrollbars to menu. It ensures that on all components the scrollbars match the jh-theme selected.


