### PR TITLE
[Tooltip] Add content slot to tooltip instead of label property

### DIFF
--- a/packages/jh-elements/components/tooltip/tooltip.js
+++ b/packages/jh-elements/components/tooltip/tooltip.js
@@ -239,6 +239,15 @@ export class JhTooltip extends LitElement {
     this.id = `tooltip-describedby-${id++}`;
   }
 
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    this.removeEventListener('focus', this.#handleOpenTooltip);
+    this.removeEventListener('mouseenter', this.#handleOpenTooltip);
+    this.removeEventListener('blur', this.#handleCloseTooltip);
+    this.removeEventListener('mouseleave', this.#handleCloseTooltip);
+    this.removeEventListener('keydown', this.#handleKeyDown);
+  }
+
   #handleContentSlotChange(e) {
     const slot = e.target;
     const hasContent = slot.assignedNodes().length > 0;
@@ -259,15 +268,6 @@ export class JhTooltip extends LitElement {
       this.removeEventListener('mouseleave', this.#handleCloseTooltip);
       this.removeEventListener('keydown', this.#handleKeyDown);
     }
-  }
-
-  disconnectedCallback() {
-    super.disconnectedCallback();
-    this.removeEventListener('focus', this.#handleOpenTooltip);
-    this.removeEventListener('mouseenter', this.#handleOpenTooltip);
-    this.removeEventListener('blur', this.#handleCloseTooltip);
-    this.removeEventListener('mouseleave', this.#handleCloseTooltip);
-    this.removeEventListener('keydown', this.#handleKeyDown);
   }
 
   #handleSlotChange(e) {

--- a/packages/jh-elements/components/tooltip/tooltip.js
+++ b/packages/jh-elements/components/tooltip/tooltip.js
@@ -13,6 +13,7 @@ const openAttr = 'open';
  * @cssprop --jh-tooltip-color-text - The tooltip text color. Defaults to `--jh-color-content-on-primary-enabled`.
  *
  * @slot default - Use to insert the element that triggers the tooltip.
+ * @slot jh-tooltip-content - Use to insert the content of the tooltip.
  *
  * @customElement jh-tooltip
  */
@@ -251,7 +252,7 @@ export class JhTooltip extends LitElement {
       this.addEventListener('keydown', this.#handleKeyDown);
     } else {
       this.#internals.role = '';
-      this.open = false;
+      this.#handleCloseTooltip();
       this.removeEventListener('focus', this.#handleOpenTooltip);
       this.removeEventListener('mouseenter', this.#handleOpenTooltip);
       this.removeEventListener('blur', this.#handleCloseTooltip);

--- a/packages/jh-elements/components/tooltip/tooltip.js
+++ b/packages/jh-elements/components/tooltip/tooltip.js
@@ -37,10 +37,10 @@ export class JhTooltip extends LitElement {
         );
         border-radius: var(--jh-border-radius-100);
         padding: var(--jh-dimension-200);
-        font-family: var(--jh-font-helper-regular-font-family);
-        font-weight: var(--jh-font-helper-regular-font-weight);
-        font-size: var(--jh-font-helper-regular-font-size);
-        line-height: var(--jh-font-helper-regular-line-height);
+        font-family: var(--jh-font-helper-bold-font-family);
+        font-weight: var(--jh-font-helper-bold-font-weight);
+        font-size: var(--jh-font-helper-bold-font-size);
+        line-height: var(--jh-font-helper-bold-line-height);
         max-width: 160px;
         width: max-content;
         position: absolute;
@@ -205,12 +205,6 @@ export class JhTooltip extends LitElement {
         attribute: 'flip-disabled',
       },
       /**
-       * Provides information about the item which triggered the tooltip.
-       */
-      label: {
-        type: String,
-      },
-      /**
        * Determines whether the tooltip is open or closed. Can be set on the tooltip to force it open.
        */
       open: {
@@ -232,8 +226,6 @@ export class JhTooltip extends LitElement {
     this.#internals = this.attachInternals();
     /**@type {?Boolean} */
     this.flipDisabled = false;
-    /** @type {?string} */
-    this.label = null;
     /**@type {?Boolean} */
     this.open = false;
     /** @type {?string} */
@@ -244,38 +236,27 @@ export class JhTooltip extends LitElement {
     super.connectedCallback();
     /** @ignore */
     this.id = `tooltip-describedby-${id++}`;
-    let observer = new MutationObserver(this.#handleEmptyLabel.bind(this));
-    let options = {
-      childList: true,
-    };
-    observer.observe(this.shadowRoot, options);
   }
 
-  #handleEmptyLabel(mutations) {
-    for (let mutation of mutations) {
-      const addedNodes = Array.from(mutation.addedNodes);
-      //check if any of the added nodes is a span
-      const spanAdded = addedNodes.some(
-        (addedNode) => addedNode.tagName === 'SPAN'
-      );
+  #handleContentSlotChange(e) {
+    const slot = e.target;
+    const hasContent = slot.assignedNodes().length > 0;
 
-      if (spanAdded) {
-        this.#internals.role = 'tooltip';
-        this.addEventListener('focus', this.#handleOpenTooltip, true);
-        this.addEventListener('mouseenter', this.#handleOpenTooltip);
-        this.addEventListener('blur', this.#handleCloseTooltip, true);
-        this.addEventListener('mouseleave', this.#handleCloseTooltip);
-        this.addEventListener('keydown', this.#handleKeyDown);
-      }
-
-      if (mutation.removedNodes.length > 0) {
-        this.#internals.role = '';
-        this.removeEventListener('focus', this.#handleOpenTooltip);
-        this.removeEventListener('mouseenter', this.#handleOpenTooltip);
-        this.removeEventListener('blur', this.#handleCloseTooltip);
-        this.removeEventListener('mouseleave', this.#handleCloseTooltip);
-        this.removeEventListener('keydown', this.#handleKeyDown);
-      }
+    if (hasContent) {
+      this.#internals.role = 'tooltip';
+      this.addEventListener('focus', this.#handleOpenTooltip, true);
+      this.addEventListener('mouseenter', this.#handleOpenTooltip);
+      this.addEventListener('blur', this.#handleCloseTooltip, true);
+      this.addEventListener('mouseleave', this.#handleCloseTooltip);
+      this.addEventListener('keydown', this.#handleKeyDown);
+    } else {
+      this.#internals.role = '';
+      this.open = false;
+      this.removeEventListener('focus', this.#handleOpenTooltip);
+      this.removeEventListener('mouseenter', this.#handleOpenTooltip);
+      this.removeEventListener('blur', this.#handleCloseTooltip);
+      this.removeEventListener('mouseleave', this.#handleCloseTooltip);
+      this.removeEventListener('keydown', this.#handleKeyDown);
     }
   }
 
@@ -288,13 +269,20 @@ export class JhTooltip extends LitElement {
     this.removeEventListener('keydown', this.#handleKeyDown);
   }
 
-  #handleSlotChange() {
+  #handleSlotChange(e) {
     //get id set previously in the constructor and set it to reference aria-describedby on the first element in the slot
     const tooltipId = this.getAttribute('id');
-    this.firstElementChild.setAttribute('aria-describedby', tooltipId);
+    const slottedElements = e.target.assignedElements();
+    const tooltipContent = this.shadowRoot.querySelector('slot[name="jh-tooltip-content"]').assignedElements();
+
+    if (slottedElements.length === 0 || tooltipContent.length === 0) {
+      return;
+    }
+    const triggerElement = slottedElements[0];
+    triggerElement.setAttribute('aria-describedby', tooltipId);
 
     //get display property of element in slot and set it on the jh-tooltip.
-    const tooltipDisplay = window.getComputedStyle(this.firstElementChild).display;
+    const tooltipDisplay = window.getComputedStyle(triggerElement).display;
     this.style.setProperty('display', tooltipDisplay );
   }
 
@@ -323,7 +311,7 @@ export class JhTooltip extends LitElement {
     //check if current position is a valid position otherwise make it fail.
     if (!['left', 'right', 'top-start', 'top-end', 'top-center', 'bottom-start', 'bottom-end', 'bottom-center'].includes(currentPosition)) return;
     
-    if (this.flipDisabled === false && this.label) {
+    if (this.flipDisabled === false) {
      
       //break current position into tooltop position and arrow position
       const [currentTooltip, currentArrow] = currentPosition.split('-');
@@ -450,10 +438,10 @@ export class JhTooltip extends LitElement {
   #getDimensions() {
     return {
       tooltipWidth: this.shadowRoot
-        .querySelector('span')
+        .querySelector('.content')
         .getBoundingClientRect().width,
       tooltipHeight: this.shadowRoot
-        .querySelector('span')
+        .querySelector('.content')
         .getBoundingClientRect().height,
       elemHeight: this.getBoundingClientRect().height,
       elemWidth: this.getBoundingClientRect().width,
@@ -475,22 +463,14 @@ export class JhTooltip extends LitElement {
   }
 
   render() {
-    let label;
-
-    if (this.label) {
-      label = html`
-        <span
-          class=${ifDefined(this.open ? 'show' : null)}
-          aria-hidden=${this.open ? 'false' : 'true'}
-        >
-          ${this.label}
-        </span>
-      `;
-    }
-
     return html`
       <slot @slotchange=${this.#handleSlotChange}></slot>
-      ${label}
+      <span
+        class="content ${ifDefined(this.open ? 'show' : null)}"
+        aria-hidden=${this.open ? 'false' : 'true'}>
+        <slot name="jh-tooltip-content" @slotchange=${this.#handleContentSlotChange}></slot>
+      </span>
+
     `;
   }
 }

--- a/packages/jh-elements/components/tooltip/tooltip.mdx
+++ b/packages/jh-elements/components/tooltip/tooltip.mdx
@@ -27,11 +27,12 @@ Import the `<jh-tooltip>` component:
 import '@jack-henry/jh-elements/components/tooltip/tooltip.js';
 ```
 
-To use `<jh-tooltip>`, place the originating element in the component's default slot.
+To use `<jh-tooltip>`, place the originating element in the component's default slot and the tooltip content in the `jh-tooltip-content` slot.
 
 ```html
-<jh-tooltip position="top-center" label="Tooltip">
+<jh-tooltip position="top-center">
   <button>Button</button>
+  <span slot="jh-tooltip-content">Tooltip</span>
 </jh-tooltip>
 ```
 

--- a/packages/jh-elements/components/tooltip/tooltip.stories.js
+++ b/packages/jh-elements/components/tooltip/tooltip.stories.js
@@ -39,7 +39,6 @@ const storyStyles = css`
 `;
 
 const disabledControls = {
-  label: { control: { disable: true } },
   position: { control: { disable: true } },
   open: { control: { disable: true } },
   'flip-disabled': { control: { disable: true } },
@@ -62,11 +61,6 @@ export default {
         'bottom-end',
       ],
     },
-    label: {
-      control: {
-        type: 'text',
-      },
-    },
     open: {
       control: {
         type: 'boolean',
@@ -84,54 +78,62 @@ export const Overview = {
   render: (args) =>
     html`<div class="overview">
       <div>
-        <jh-tooltip label="top-start" position="top-start"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="top-start">
+          <span slot="jh-tooltip-content">top-start</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="top-center" position="top-center"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="top-center">
+          <span slot="jh-tooltip-content">top-center</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="top-end" position="top-end"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="top-end">
+          <span slot="jh-tooltip-content">top-end</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
       </div>
       <div class="overviewSides">
-        <jh-tooltip label="left" position="left"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="left">
+          <span slot="jh-tooltip-content">left</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="right" position="right"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="right">
+          <span slot="jh-tooltip-content">right</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
       </div>
       <div>
-        <jh-tooltip label="bottom-start" position="bottom-start"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="bottom-start">
+          <span slot="jh-tooltip-content">bottom-start</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="bottom-center" position="bottom-center"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="bottom-center">
+          <span slot="jh-tooltip-content">bottom-center</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
-        <jh-tooltip label="bottom-end" position="bottom-end"
-          ><jh-button icon-position="before" accessible-label="view more"
+        <jh-tooltip position="bottom-end">
+          <span slot="jh-tooltip-content">bottom-end</span>
+          <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon"
             ></jh-icon-ellipsis></jh-button
@@ -150,17 +152,16 @@ export const Playground = {
   render: (args) =>
     html` <div class="center">
       <jh-tooltip
-        label=${args.label}
         position=${args.position}
         ?open=${args.open}
-        ?flip-disabled=${args['flip-disabled']}
-        ><jh-button label="Modify me!"></jh-button
-      ></jh-tooltip>
+        ?flip-disabled=${args['flip-disabled']}>
+        <jh-button label="Modify me!"></jh-button>
+        <div slot="jh-tooltip-content">I am a tooltip with a long text that will wrap to the next line at 160px</div>
+      </jh-tooltip>
     </div>`,
 };
 
 Playground.args = {
-  label: 'Tooltip',
   position: 'top-center',
   open: false,
   'flip-disabled': false,
@@ -173,8 +174,9 @@ Playground.parameters = {
 export const Default = {
   render: (args) =>
     html` <div class="center">
-      <jh-tooltip label="top-center" position="top-center"
-        ><jh-button label="Default"></jh-button
+      <jh-tooltip position="top-center">
+        <span slot="jh-tooltip-content">top-center</span>
+        <jh-button label="Default"></jh-button
       ></jh-tooltip>
     </div>`,
 };
@@ -190,10 +192,10 @@ export const ManuallyOpen = {
   render: (args) =>
     html` <div class="center">
       <jh-tooltip
-        label="Open Tooltip"
         position=${args.position}
-        ?open=${args.open}
-        ><jh-button label="Open"></jh-button
+        ?open=${args.open}>
+        <span slot="jh-tooltip-content">Open Tooltip</span>
+        <jh-button label="Open"></jh-button
       ></jh-tooltip>
     </div>`,
 };
@@ -205,7 +207,6 @@ ManuallyOpen.parameters = {
   styles: storyStyles,
 };
 ManuallyOpen.argTypes = {
-  label: { table: { disable: true } },
   'flip-disabled': { table: { disable: true } },
 };
 
@@ -213,16 +214,13 @@ export const FlippingTooltip = {
   render: (args) =>
     html`
       <div class="flipping-tooltip">
-        <jh-tooltip
-          label="I am a default tooltip that flips"
-          position=${args.position}
-          ><jh-button label="Flip"></jh-button
+        <jh-tooltip position=${args.position}>
+          <span slot="jh-tooltip-content">I am a default tooltip that flips</span>
+          <jh-button label="Flip"></jh-button
         ></jh-tooltip>
-        <jh-tooltip
-          label="I am a tooltip that doesn't flip"
-          position=${args.position}
-          flip-disabled
-          ><jh-button label="No Flip"></jh-button
+        <jh-tooltip position=${args.position} flip-disabled>
+          <span slot="jh-tooltip-content">I am a tooltip that doesn't flip</span>
+          <jh-button label="No Flip"></jh-button
         ></jh-tooltip>
       </div>
     `,
@@ -235,7 +233,6 @@ FlippingTooltip.parameters = {
   styles: storyStyles,
 };
 FlippingTooltip.argTypes = {
-  label: { table: { disable: true } },
   open: { table: { disable: true } },
   'flip-disabled': { table: { disable: true } },
 };

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6844,11 +6844,6 @@
           "default": "false"
         },
         {
-          "name": "label",
-          "description": "Provides information about the item which triggered the tooltip.",
-          "type": "?string"
-        },
-        {
           "name": "open",
           "description": "Determines whether the tooltip is open or closed. Can be set on the tooltip to force it open.",
           "type": "?Boolean",
@@ -6870,12 +6865,6 @@
           "default": "false"
         },
         {
-          "name": "label",
-          "attribute": "label",
-          "description": "Provides information about the item which triggered the tooltip.",
-          "type": "?string"
-        },
-        {
           "name": "open",
           "attribute": "open",
           "description": "Determines whether the tooltip is open or closed. Can be set on the tooltip to force it open.",
@@ -6894,6 +6883,10 @@
         {
           "name": "default",
           "description": "Use to insert the element that triggers the tooltip."
+        },
+        {
+          "name": "jh-tooltip-content",
+          "description": "Use to insert the content of the tooltip."
         }
       ],
       "cssProperties": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It refactors `jh-tooltip` to use a slot for content instead of the current label property. It also adjusts the font from helper-regular to helper-bold.

**Idea number or other reference :** 186

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details** 
Make sure the `label` property has also been removed from all stories and examples.

## Notes/Dependencies

N/A


