### PR TITLE
[Radio Group] Added disabled state to radio-group

### DIFF
--- a/packages/jh-elements/components/radio-group/radio-group.js
+++ b/packages/jh-elements/components/radio-group/radio-group.js
@@ -139,6 +139,7 @@ export class JhRadioGroup extends LitElement {
         type: String,
         attribute: 'accessible-label',
       },
+      /** Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT). */      
       disabled: {
         type: Boolean,
         reflect: true

--- a/packages/jh-elements/components/radio-group/radio-group.js
+++ b/packages/jh-elements/components/radio-group/radio-group.js
@@ -199,7 +199,7 @@ export class JhRadioGroup extends LitElement {
     this.#internals = this.attachInternals();
     /** @type {?string} */
     this.accessibleLabel = null;
-    /** @type {?Boolean} */
+    /** @type {boolean} */
     this.disabled = false;
     /** @type {?string} */
     this.errorText = null;
@@ -231,7 +231,6 @@ export class JhRadioGroup extends LitElement {
   }
 
   firstUpdated() {
-    const slot = this.renderRoot.querySelector('slot');
     this._syncDisabledToChildren();
   }
 
@@ -302,7 +301,7 @@ export class JhRadioGroup extends LitElement {
       radios[0].tabIndex = 0;
     }
 
-    this._syncDisabledToChildren
+    this._syncDisabledToChildren();
   }
 
   #handleChange(e) {

--- a/packages/jh-elements/components/radio-group/radio-group.js
+++ b/packages/jh-elements/components/radio-group/radio-group.js
@@ -17,6 +17,7 @@ let id = 0;
  * Defaults to `--jh-color-content-secondary-enabled`.
  * @cssprop --jh-radio-group-error-color-text - The error-text text color. 
  * Defaults to `--jh-color-content-negative-enabled`.
+ * @cssprop --jh-radio-group-opacity-disabled - The opacity of the radio group when disabled. Defaults to `--jh-opacity-disabled`.
  *
  * @slot default - Use to insert `<jh-radio>` components(s).
  * 
@@ -50,6 +51,18 @@ export class JhRadioGroup extends LitElement {
         border: none;
         padding: 0;
         margin: 0;
+      }
+      :host([disabled]) {
+        --group-disabled-opacity: var(--jh-radio-group-opacity-disabled, var(--jh-opacity-disabled));
+      }
+      :host([disabled]) .label,
+      :host([disabled]) .helper-text,
+      :host([disabled]) .error-text {
+        opacity: var(--group-disabled-opacity);
+        pointer-events: none;
+      }
+      :host([disabled]) ::slotted(jh-radio) {
+        --jh-radio-opacity-disabled: var(--group-disabled-opacity);
       }
       :host legend {
         padding: 0;
@@ -126,6 +139,10 @@ export class JhRadioGroup extends LitElement {
         type: String,
         attribute: 'accessible-label',
       },
+      disabled: {
+        type: Boolean,
+        reflect: true
+      },
       /** Text to be displayed when radio group has failed validation and `invalid` is true. */
       errorText: {
         type: String,
@@ -181,17 +198,19 @@ export class JhRadioGroup extends LitElement {
     this.#internals = this.attachInternals();
     /** @type {?string} */
     this.accessibleLabel = null;
+    /** @type {?Boolean} */
+    this.disabled = false;
     /** @type {?string} */
     this.errorText = null;
     /** @type {?string} */
     this.helperText = null;
-    /** @type {?Boolean} */
+    /** @type {?boolean} */
     this.invalid = false;
     /** @type {?string} */
     this.label = null;
     /** @type {?string} */
     this.name = null;
-    /** @type {?Boolean} */
+    /** @type {?boolean} */
     this.required = false;
     /** @type {'vertical'|'horizontal'} */
     this.orientation = 'vertical';
@@ -208,6 +227,17 @@ export class JhRadioGroup extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     this.#id = id++;
+  }
+
+  firstUpdated() {
+    const slot = this.renderRoot.querySelector('slot');
+    this._syncDisabledToChildren();
+  }
+
+  updated(changedProperties) {
+    if (changedProperties.has('disabled')) {
+      this._syncDisabledToChildren();
+    }
   }
 
   /**
@@ -237,6 +267,16 @@ export class JhRadioGroup extends LitElement {
     this.requestUpdate('value', oldValue);
   }
 
+  _syncDisabledToChildren() {
+    const slot = this.renderRoot.querySelector('slot');
+    if(!slot) return;
+
+    const radios = slot.assignedElements().filter((el) => el.tagName === 'JH-RADIO');
+    radios.forEach((radio) => {
+      radio.disabled = this.disabled;
+    });
+  }
+
   #getRadios() {
     return [...this.querySelectorAll('jh-radio')];
   }
@@ -260,6 +300,8 @@ export class JhRadioGroup extends LitElement {
     if (!this.#checked) {
       radios[0].tabIndex = 0;
     }
+
+    this._syncDisabledToChildren
   }
 
   #handleChange(e) {
@@ -384,6 +426,7 @@ export class JhRadioGroup extends LitElement {
         role="radiogroup"
         id=${ifDefined(this.label ? `radio-group-label-${this.#id}` : null)}
         aria-describedby=${ifDefined(this.#getAriaDescribedBy())}
+        aria-disabled=${ifDefined(this.disabled ? 'true' : null)}
         aria-required=${ifDefined(this.required ? 'true' : 'false')}
         aria-invalid=${ifDefined(this.invalid ? 'true' : null)}
         aria-label=${ifDefined(this.accessibleLabel)}

--- a/packages/jh-elements/components/radio-group/radio-group.stories.js
+++ b/packages/jh-elements/components/radio-group/radio-group.stories.js
@@ -22,6 +22,7 @@ const storyStyles = css`
 `;
 
 const disableControls = {
+  disabled: { control: { disable: true } },
   label: { control: { disable: true } },
   'helper-text': { control: { disable: true } },
   'error-text': { control: { disable: true } },
@@ -43,6 +44,9 @@ export default {
     },
   },
   argTypes: {
+    disabled: {
+      control: 'boolean',
+    },
     required: {
       control: 'boolean',
     },
@@ -112,6 +116,20 @@ export const Overview = {
         orientation="horizontal"
         error-text="Error text"
         invalid
+        disabled
+      >
+        <jh-radio label="radio 4" value="radio-4"></jh-radio>
+        <jh-radio label="radio 5" value="radio-5" disabled></jh-radio>
+        <jh-radio label="radio 6" value="radio-6"></jh-radio>
+      </jh-radio-group>
+    </div>
+    <div class="container">
+      <jh-radio-group
+        label="Label"
+        helper-text="Helper text group"
+        orientation="horizontal"
+        error-text="Error text"
+        invalid
       >
         <jh-radio label="radio 4" value="radio-4"></jh-radio>
         <jh-radio label="radio 5" value="radio-5" disabled></jh-radio>
@@ -140,6 +158,7 @@ export const Playground = {
       ?invalid=${args.invalid}
       error-text=${args['error-text']}
       value=${args.value}
+      ?disabled=${args.disabled}
     >
       <jh-radio
         label="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur metus massa, mollis euismod lorem ut"
@@ -162,6 +181,7 @@ Playground.args = {
   invalid: true,
   'error-text': 'Error',
   value: 'radio-1',
+  disabled: false,
 };
 Playground.parameters = {
   styles: storyStyles,

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5250,6 +5250,7 @@
         },
         {
           "name": "disabled",
+          "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
           "type": "?Boolean",
           "default": "false"
         },
@@ -5318,6 +5319,7 @@
         {
           "name": "disabled",
           "attribute": "disabled",
+          "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
           "type": "?Boolean",
           "default": "false"
         },

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5249,6 +5249,11 @@
           "type": "?string"
         },
         {
+          "name": "disabled",
+          "type": "?Boolean",
+          "default": "false"
+        },
+        {
           "name": "error-text",
           "description": "Text to be displayed when radio group has failed validation and `invalid` is true.",
           "type": "?string"
@@ -5261,7 +5266,7 @@
         {
           "name": "invalid",
           "description": "Sets an `aria-invalid` on the radio group to indicate the value supplied was invalid and displays `error-text` when set.",
-          "type": "?Boolean",
+          "type": "?boolean",
           "default": "false"
         },
         {
@@ -5277,7 +5282,7 @@
         {
           "name": "required",
           "description": "Indicates a value is required.",
-          "type": "?Boolean",
+          "type": "?boolean",
           "default": "false"
         },
         {
@@ -5311,6 +5316,12 @@
           "type": "?string"
         },
         {
+          "name": "disabled",
+          "attribute": "disabled",
+          "type": "?Boolean",
+          "default": "false"
+        },
+        {
           "name": "errorText",
           "attribute": "error-text",
           "description": "Text to be displayed when radio group has failed validation and `invalid` is true.",
@@ -5326,7 +5337,7 @@
           "name": "invalid",
           "attribute": "invalid",
           "description": "Sets an `aria-invalid` on the radio group to indicate the value supplied was invalid and displays `error-text` when set.",
-          "type": "?Boolean",
+          "type": "?boolean",
           "default": "false"
         },
         {
@@ -5345,7 +5356,7 @@
           "name": "required",
           "attribute": "required",
           "description": "Indicates a value is required.",
-          "type": "?Boolean",
+          "type": "?boolean",
           "default": "false"
         },
         {
@@ -5401,6 +5412,10 @@
         {
           "name": "--jh-radio-group-error-color-text",
           "description": "The error-text text color. \nDefaults to `--jh-color-content-negative-enabled`."
+        },
+        {
+          "name": "--jh-radio-group-opacity-disabled",
+          "description": "The opacity of the radio group when disabled. Defaults to `--jh-opacity-disabled`."
         }
       ]
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds support for a disabled state at the radio group level. When disabled is set on the radio-group, all slotted jh-radio components will now have their disabled state set.

Idea number or other reference : DSPD-203

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

N/A


