### PR TITLE
[Input-textarea] Refactors template to adopt jh-input public methods

### DIFF
--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -177,7 +177,7 @@ export class JhInputTextarea extends JhInput {
   constructor() {
     super();
     /** @type {boolean} */
-    this.autoGrow = null;
+    this.autoGrow = false;
     /** @type {?string} */
     this.cols = null;
     /** @type {boolean} */

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -18,6 +18,12 @@ let id = 0;
 export class JhInputTextarea extends JhInput {
   /** @type {?number} */
   #id;
+  /** @type {?ResizeObserver} */
+  #resizeObserver;
+  /** @type {?HTMLTextAreaElement} */
+  #textareaEl;
+  /** @type {?HTMLElement} */
+  #footerContent;
 
   static get styles() {
     return [
@@ -189,191 +195,83 @@ export class JhInputTextarea extends JhInput {
     this.#id = id++;
   }
 
-  firstUpdated() {
-    // add resize observer to update width of footer when textarea width changes
-    let footerContent = this.shadowRoot.querySelector('.footer-content');
-    let textareaEl = this.shadowRoot.querySelector('textarea');
+  disconnectedCallback() {
+    super.disconnectedCallback();
+    if (this.#resizeObserver) {
+      this.#resizeObserver.unobserve(this.#textareaEl);
+      this.#resizeObserver.disconnect();
+      this.#resizeObserver = null;
+    }
+    this.#textareaEl = null;
+    this.#footerContent = null;
+  }
 
-    if (footerContent) {
-      new ResizeObserver(() => {
-        this.#updateFooterWidth(footerContent, textareaEl);
-      }).observe(textareaEl);
+  firstUpdated() {
+    this.#textareaEl = this.shadowRoot.querySelector('textarea');
+    this.#footerContent = this.shadowRoot.querySelector('.footer-content');
+    
+    // add resize observer to update width of footer when textarea width changes
+    if (this.#footerContent) {
+      this.#resizeObserver = new ResizeObserver(() => {
+        this.#updateFooterWidth();
+      });
+      this.#resizeObserver.observe(this.#textareaEl);
     }
   }
 
-  #updateFooterWidth(footerContent, textareaEl) {
-    footerContent.style.width = textareaEl.offsetWidth + 'px';
+  #updateFooterWidth() {
+    if (this.#footerContent) {
+      this.#footerContent.style.width = this.#textareaEl.offsetWidth + 'px';
+    }
   }
 
-  #dispatch(eventName, details) {
-    this.dispatchEvent(
-      new CustomEvent(eventName, {
-        detail: details,
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      })
-    );
-  }
-
-  #handleInput(e) {
-    this.value = e.target.value;
-
-    this.#dispatch('jh-input', { value: this.value } );
-
+  _handleInput(e) {
+    super._handleInput(e);
+    
+    // add textarea specific autogrow
     if (this.autoGrow) {
       this.#autoGrowTextarea();
     }
   }
 
   #autoGrowTextarea() {
-    let textareaEl = this.shadowRoot.querySelector('textarea');
-    textareaEl.style.height = 'auto';
-    textareaEl.style.height = textareaEl.scrollHeight + 'px';
-  }
-
-  #handleChange() {
-    let payload = {
-      'value': this.value,
-    };
-    this.#dispatch('jh-change', payload);
-  }
-
-  #handleSelect(e) {
-    const selectedString = e.target.value.substring(
-      e.target.selectionStart,
-      e.target.selectionEnd
-    );
-
-    if (selectedString) {
-      this.#dispatch('jh-select', {
-        selected: selectedString,
-        selectionStart: e.target.selectionStart,
-        selectionEnd: e.target.selectionEnd,
-      });
+    if (!this.#textareaEl) {
+      this.#textareaEl = this.shadowRoot.querySelector('textarea');
+    }
+    
+    if (this.#textareaEl) {
+      // Reset height to auto to get the correct scrollHeight
+      this.#textareaEl.style.height = 'auto';
+      // Set height to scrollHeight to accommodate content
+      this.#textareaEl.style.height = `${this.#textareaEl.scrollHeight}px`;
     }
   }
 
-  #handleMaxlength() {
-    this.#dispatch('jh-maxlength');
-  }
-
-  #getDescribedby() {
-    let describedbyString = '';
-
-    if (this.errorText) {
-      describedbyString += `jh-input-error-${this.#id}`;
-    }
-    if (this.helperText) {
-      describedbyString += ` jh-input-helper-${this.#id}`;
-    }
-    if (this.showCharCount) {
-      describedbyString += ` jh-input-counter-${this.#id}`;
-    }
-    return describedbyString;
-  }
-
-  render() {
-    let label;
-    let indicator;
-    let helperText;
-    let input;
-    let footer;
-    let errorText;
-    let charCount;
-    let describedby;
-
-    if (this.label) {
-      if (this.showIndicator) {
-        if (this.required) {
-          indicator = html`<span class="indicator" aria-hidden="true"> *</span>`;
-        } else {
-          indicator = html`<span class="indicator"> (optional)</span>`;
-        }
-      }
-
-      if (this.helperText) {
-        helperText = html`
-          <p id="jh-input-helper-${this.#id}" class="helper-text">
-            ${this.helperText}
-          </p>
-        `;
-      }
-
-      label = html`
-        <label for="jh-input-${this.#id}">${this.label}${indicator}</label>
-        ${helperText}
-      `;
-    }
-
-    if (this.showCharCount) {
-      let valueLength = this.value ? this.value.length : 0;
-      let charCountValue = `${this.maxlength ? `${valueLength}/${this.maxlength}` : valueLength}`;
-
-      if (valueLength && valueLength === Number(this.maxlength)) {
-        this.#handleMaxlength();
-      }
-
-      charCount = html`
-        <p class="counter" aria-hidden="true">${charCountValue}</p>
-      `;
-    }
-
-    if (this.invalid && this.errorText) {
-      errorText = html`
-        <p id="jh-input-error-${this.#id}" class="error-text">
-          ${this.errorText}
-        </p>
-      `;
-    }
-
-    if ((this.invalid && this.errorText) || this.showCharCount) {
-      footer = html`
-        <div class="footer-content">
-          ${errorText}
-          ${charCount}
-        </div>
-      `;
-    }
-
-    if (helperText || errorText || charCount) {
-      describedby = this.#getDescribedby();
-    }
-
-    input = html`
-        <textarea
-          id="jh-input-${this.#id}"
-          aria-describedby=${describedby}
-          aria-invalid=${ifDefined(this.invalid ? 'true' : null)}
-          aria-label=${ifDefined(
-            this.accessibleLabel === '' ? null : this.accessibleLabel
-          )}
-          autocomplete=${ifDefined(
-            this.autocomplete === '' ? null : this.autocomplete
-          )}          
-          cols=${ifDefined(this.cols === '' ? null : this.cols)}
-          ?disabled=${this.disabled}
-          enterkeyhint=${ifDefined(
-            this.enterkeyhint === '' ? null : this.enterkeyhint
-          )}
-          inputmode=${ifDefined(this.inputmode === '' ? null : this.inputmode)}
-          maxlength=${ifDefined(this.maxlength === '' ? null : this.maxlength)}
-          minlength=${ifDefined(this.minlength === '' ? null : this.minlength)}
-          name=${ifDefined(this.name === '' ? null : this.name)}
-          ?readonly=${this.readonly}
-          ?required=${this.required}
-          rows=${ifDefined(this.rows === '' ? null : this.rows)}
-          .value=${this.value}
-          wrap=${ifDefined(this.wrap === '' ? null : this.wrap)}
-          @change=${this.#handleChange}
-          @select=${this.#handleSelect}
-          @input=${this.#handleInput}
-        ></textarea>
-    `;
-
+  renderInput() {
     return html`
-      ${label} ${input} ${footer}
-    `;
+      <textarea
+        id="jh-input-${this.#id}"
+        aria-describedby=${this._getDescribedby()}
+        aria-invalid=${ifDefined(this.invalid ? 'true' : null)}
+        aria-label=${ifDefined(this.accessibleLabel === '' ? null : this.accessibleLabel)}
+        autocomplete=${ifDefined(this.autocomplete === '' ? null : this.autocomplete)}
+        cols=${ifDefined(this.cols ? Number(this.cols) : null)}
+        ?disabled=${this.disabled}
+        enterkeyhint=${ifDefined(this.enterkeyhint || null)}
+        inputmode=${ifDefined(this.inputmode || null)}
+        maxlength=${ifDefined(this.maxlength ? Number(this.maxlength) : null)}
+        minlength=${ifDefined(this.minlength ? Number(this.minlength) : null)}
+        name=${ifDefined(this.name || null)}
+        ?readonly=${this.readonly}
+        ?required=${this.required}
+        rows=${ifDefined(this.rows ? Number(this.rows) : null)}
+        .value=${this.value}
+        wrap=${ifDefined(this.wrap || null)}
+        @change=${this._handleChange}
+        @input=${this._handleInput}
+        @select=${this._handleSelect}
+        ></textarea>
+    `
   }
 }
 customElements.define('jh-input-textarea', JhInputTextarea);

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -235,16 +235,10 @@ export class JhInputTextarea extends JhInput {
   }
 
   #autoGrowTextarea() {
-    if (!this.#textareaEl) {
-      this.#textareaEl = this.shadowRoot.querySelector('textarea');
-    }
-    
-    if (this.#textareaEl) {
-      // Reset height to auto to get the correct scrollHeight
-      this.#textareaEl.style.height = 'auto';
-      // Set height to scrollHeight to accommodate content
-      this.#textareaEl.style.height = `${this.#textareaEl.scrollHeight}px`;
-    }
+    // Reset height to auto to get the correct scrollHeight
+    this.#textareaEl.style.height = 'auto';
+    // Set height to scrollHeight to accommodate content
+    this.#textareaEl.style.height = `${this.#textareaEl.scrollHeight}px`;
   }
 
   renderInput() {

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -128,6 +128,7 @@ export class JhInputTextarea extends JhInput {
         );
       }
       :host([readonly]) textarea {
+        background-color: transparent;
         height: auto;
         border: none;
         padding-left: 0;

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -163,14 +163,14 @@ export class JhInputTextarea extends JhInput {
         attribute: 'auto-grow',
       },
       /** Sets the width of the input field. */
-      cols: { type: String },
+      cols: { type: Number },
       /** Removes native resize capability of the input field. */
       noResize: {
         type: Boolean,
         attribute: 'no-resize',
       },
       /** Sets the height of the input field. */
-      rows: { type: String },
+      rows: { type: Number },
       /** Specifies how text should be wrapped when submitted in a form. The `cols` property must be set for `wrap='hard'` to take effect. */
       wrap: { type: String },
       /** Prevents users from changing the input value. */
@@ -182,11 +182,11 @@ export class JhInputTextarea extends JhInput {
     super();
     /** @type {boolean} */
     this.autoGrow = false;
-    /** @type {?string} */
+    /** @type {?number} */
     this.cols = null;
     /** @type {boolean} */
     this.noResize = true;
-    /** @type {?string} */
+    /** @type {?number} */
     this.rows = null;
     /** @type {'small'|'medium'|'large'} */
     this.size = 'medium';

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -20,10 +20,14 @@ export class JhInputTextarea extends JhInput {
   #id;
   /** @type {?ResizeObserver} */
   #resizeObserver;
-  /** @type {?HTMLTextAreaElement} */
-  #textareaEl;
-  /** @type {?HTMLElement} */
-  #footerContent;
+
+  get #textareaEl() {
+    return this.renderRoot?.querySelector('textarea');
+  }
+
+  get #footerContent() {
+    return this.renderRoot?.querySelector('.footer-content');
+  }
 
   static get styles() {
     return [
@@ -202,14 +206,9 @@ export class JhInputTextarea extends JhInput {
       this.#resizeObserver.disconnect();
       this.#resizeObserver = null;
     }
-    this.#textareaEl = null;
-    this.#footerContent = null;
   }
 
   firstUpdated() {
-    this.#textareaEl = this.shadowRoot.querySelector('textarea');
-    this.#footerContent = this.shadowRoot.querySelector('.footer-content');
-    
     // add resize observer to update width of footer when textarea width changes
     if (this.#footerContent) {
       this.#resizeObserver = new ResizeObserver(() => {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -3158,7 +3158,7 @@
         {
           "name": "cols",
           "description": "Sets the width of the input field.",
-          "type": "?string"
+          "type": "?number"
         },
         {
           "name": "no-resize",
@@ -3169,7 +3169,7 @@
         {
           "name": "rows",
           "description": "Sets the height of the input field.",
-          "type": "?string"
+          "type": "?number"
         },
         {
           "name": "wrap",
@@ -3314,7 +3314,7 @@
           "name": "cols",
           "attribute": "cols",
           "description": "Sets the width of the input field.",
-          "type": "?string"
+          "type": "?number"
         },
         {
           "name": "noResize",
@@ -3327,7 +3327,7 @@
           "name": "rows",
           "attribute": "rows",
           "description": "Sets the height of the input field.",
-          "type": "?string"
+          "type": "?number"
         },
         {
           "name": "wrap",

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -3152,7 +3152,8 @@
         {
           "name": "auto-grow",
           "description": "Enables the input height to grow automatically to accommodate user input. `auto-grow` will also remove the input's native resize capability.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": "false"
         },
         {
           "name": "cols",
@@ -3306,7 +3307,8 @@
           "name": "autoGrow",
           "attribute": "auto-grow",
           "description": "Enables the input height to grow automatically to accommodate user input. `auto-grow` will also remove the input's native resize capability.",
-          "type": "boolean"
+          "type": "boolean",
+          "default": "false"
         },
         {
           "name": "cols",
@@ -5251,7 +5253,7 @@
         {
           "name": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {
@@ -5320,7 +5322,7 @@
           "name": "disabled",
           "attribute": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- Refactors the `input-textarea` template to adopt `jh-input` public methods. 
- Corrects the `auto-grow` default value from `null` to `false`. 
- Removes `aria-describedby` from the character counter to align with the jh-input implementation. 
- Adds `transparent` background color when in `readonly`.

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a


