### PR TITLE
[Button] Add support for icons on left and right side together

### DIFF
--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -102,9 +102,10 @@ import '../progress/progress.js';
  * @cssprop --jh-button-border-radius - The button container border-radius. Defaults to `--jh-border-radius-100`.
  * @cssprop --jh-button-opacity-disabled - The button container opacity when disabled. Defaults to `--jh-opacity-disabled`.
  * @cssprop --jh-button-color-focus - The button container outline when it receives keyboard focus. Defaults to `--jh-border-focus-color`.
- * @cssprop --jh-button-size - The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size="small"`, `--jh-dimension-1200` when `size="medium"`, and `--jh-dimension-1400` when `size="large"`. 
+ * @cssprop --jh-button-size - The button width of icon-only buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size="small"`, `--jh-dimension-1200` when `size="medium"`, and `--jh-dimension-1400` when `size="large"`. 
  *
- * @slot jh-button-icon - Use to insert an icon.
+ * @slot jh-button-icon-left - Use to insert an icon on the left side of the button and for `icon-only` buttons.
+ * @slot jh-button-icon-right - Use to insert an icon on the right side of the button.
  * @customElement jh-button
  */
 export class JhButton extends LitElement {
@@ -156,6 +157,7 @@ export class JhButton extends LitElement {
         display: flex;
         justify-content: center;
         align-items: center;
+        gap: var(--jh-dimension-200);
       }
       button:focus,
       a:focus {
@@ -687,32 +689,18 @@ export class JhButton extends LitElement {
           var(--jh-color-content-on-negative-enabled)
         );
       }
-      /* Icon-related Type option styling */
-      :host([icon-position='before'][label]) ::slotted(*) {
-        margin-right: var(--jh-dimension-200);
-      }
-      :host([icon-position='after'][label]) ::slotted(*) {
-        margin-left: var(--jh-dimension-200);
-      }
-      :host([icon-position='after']) .content-wrapper {
-        flex-direction: row-reverse;
-      }
       /* Icon only styling */
-      :host(:not([label])[size='small']) button,
-      :host(:not([label])[size='small']) a {
+      :host([icon-only][size='small']) button,
+      :host([icon-only][size='small']) a {
         width: var(--jh-button-size, var(--jh-dimension-1000));
       }
-      :host(:not([label])[size='medium']) button,
-      :host(:not([label])[size='medium']) a {
+      :host([icon-only][size='medium']) button,
+      :host([icon-only][size='medium']) a {
         width: var(--jh-button-size, var(--jh-dimension-1200));
       }
-      :host(:not([label])[size='large']) button,
-      :host(:not([label])[size='large']) a {
+      :host([icon-only][size='large']) button,
+      :host([icon-only][size='large']) a {
         width: var(--jh-button-size, var(--jh-dimension-1400));
-      }
-      :host(:not([label])) button,
-      :host(:not([label])) a {
-        padding: 0;
       }
       /* Block styling */
       :host([block]) {
@@ -721,6 +709,8 @@ export class JhButton extends LitElement {
       }
       :host(:not([label])[block]) button,
       :host(:not([label])[block]) a,
+      :host([icon-only][block]) button,
+      :host([icon-only][block]) a,
       :host([block]) button,
       :host([block]) a {
         width: 100%;
@@ -759,10 +749,10 @@ export class JhButton extends LitElement {
       href: {
         type: String,
       },
-      /** Sets location of icon in relation to the label. */
-      iconPosition: {
-        type: String,
-        attribute: 'icon-position',
+      /** Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot. */
+      iconOnly: {
+        type: Boolean,
+        attribute: 'icon-only',
         reflect: true,
       },
       /** Displays a progress indicator. */
@@ -816,8 +806,8 @@ export class JhButton extends LitElement {
     this.disabled = false;
     /** @type {?string} */
     this.href = null;
-    /** @type {'before'|'after'} */
-    this.iconPosition = 'before';
+    /** @type {boolean} */
+    this.iconOnly = false;
     /** @type {?boolean} */
     this.pending = false;
     /** @type {?string} */
@@ -900,13 +890,24 @@ export class JhButton extends LitElement {
       buttonContent = html`
         <jh-progress type="circular" indeterminate></jh-progress>
       `;
+    } else if (this.iconOnly) {
+      buttonContent = html`
+        <slot
+          name="jh-button-icon-left"
+          @slotchange=${this.#handleSlotChange}
+        ></slot>
+      `;
     } else {
       buttonContent = html`
         <slot
-          name="jh-button-icon"
+          name="jh-button-icon-left"
           @slotchange=${this.#handleSlotChange}
         ></slot>
         ${buttonLabel}
+        <slot
+          name="jh-button-icon-right"
+          @slotchange=${this.#handleSlotChange}
+        ></slot>
       `;
     }
 

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -4,6 +4,7 @@
 
 import { LitElement, css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { classMap } from 'lit/directives/class-map.js';
 import '../progress/progress.js';
 
 /**
@@ -102,10 +103,10 @@ import '../progress/progress.js';
  * @cssprop --jh-button-border-radius - The button container border-radius. Defaults to `--jh-border-radius-100`.
  * @cssprop --jh-button-opacity-disabled - The button container opacity when disabled. Defaults to `--jh-opacity-disabled`.
  * @cssprop --jh-button-color-focus - The button container outline when it receives keyboard focus. Defaults to `--jh-border-focus-color`.
- * @cssprop --jh-button-size - The button width of icon-only buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size="small"`, `--jh-dimension-1200` when `size="medium"`, and `--jh-dimension-1400` when `size="large"`. 
+ * @cssprop --jh-button-size - The button width of single icon buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size="small"`, `--jh-dimension-1200` when `size="medium"`, and `--jh-dimension-1400` when `size="large"`. 
  *
- * @slot jh-button-icon-left - Use to insert an icon on the left side of the button and for `icon-only` buttons.
- * @slot jh-button-icon-right - Use to insert an icon on the right side of the button.
+ * @slot jh-button-icon-left - Use to insert an icon on the left side of the button and for single icon buttons.
+ * @slot jh-button-icon-right - Use to insert an icon on the right side of the button and for single icon buttons.
  * @customElement jh-button
  */
 export class JhButton extends LitElement {
@@ -689,17 +690,22 @@ export class JhButton extends LitElement {
           var(--jh-color-content-on-negative-enabled)
         );
       }
-      /* Icon only styling */
-      :host([icon-only][size='small']) button,
-      :host([icon-only][size='small']) a {
+
+      /* Single icon styling */
+      :host button.single-icon,
+      :host a.single-icon {
+        padding: 0;
+      }
+      :host([size='small']) button.single-icon,
+      :host([size='small']) a.single-icon {
         width: var(--jh-button-size, var(--jh-dimension-1000));
       }
-      :host([icon-only][size='medium']) button,
-      :host([icon-only][size='medium']) a {
+      :host([size='medium']) button.single-icon,
+      :host([size='medium']) a.single-icon {
         width: var(--jh-button-size, var(--jh-dimension-1200));
       }
-      :host([icon-only][size='large']) button,
-      :host([icon-only][size='large']) a {
+      :host([size='large']) button.single-icon,
+      :host([size='large']) a.single-icon {
         width: var(--jh-button-size, var(--jh-dimension-1400));
       }
       /* Block styling */
@@ -709,8 +715,8 @@ export class JhButton extends LitElement {
       }
       :host(:not([label])[block]) button,
       :host(:not([label])[block]) a,
-      :host([icon-only][block]) button,
-      :host([icon-only][block]) a,
+      :host([block]) button.single-icon,
+      :host([block]) a.single-icon,
       :host([block]) button,
       :host([block]) a {
         width: 100%;
@@ -749,12 +755,6 @@ export class JhButton extends LitElement {
       href: {
         type: String,
       },
-      /** Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot. */
-      iconOnly: {
-        type: Boolean,
-        attribute: 'icon-only',
-        reflect: true,
-      },
       /** Displays a progress indicator. */
       pending: {
         type: Boolean,
@@ -785,6 +785,14 @@ export class JhButton extends LitElement {
       value: {
         type: String,
       },
+      _hasLeftSlotContent: {
+        type: Boolean,
+        state: true,
+      },
+      _hasRightSlotContent: {
+        type: Boolean,
+        state: true,
+      },
     };
   }
 
@@ -806,8 +814,6 @@ export class JhButton extends LitElement {
     this.disabled = false;
     /** @type {?string} */
     this.href = null;
-    /** @type {boolean} */
-    this.iconOnly = false;
     /** @type {?boolean} */
     this.pending = false;
     /** @type {?string} */
@@ -822,6 +828,10 @@ export class JhButton extends LitElement {
     this.target = null;
     /** @type {?string} */
     this.value = null;
+    /** @type {boolean} */
+    this._hasLeftSlotContent = false;
+    /** @type {boolean} */
+    this._hasRightSlotContent = false;
 
     this.addEventListener('click', this.#onClick);
     this.addEventListener('keydown', this.#handleKeydown);
@@ -873,10 +883,36 @@ export class JhButton extends LitElement {
     }
   }
 
-  #handleSlotChange() {
-    this.firstElementChild.setAttribute('aria-hidden', 'true');
-    this.firstElementChild.setAttribute('size', 'medium');
+  #handleSlotChange(e) {
+
+    let newSlottedElement = e.target.assignedElements()[0];
+    let slot = e.target;
+
+    if (slot.name !== 'jh-button-icon-left' && slot.name !== 'jh-button-icon-right') {
+      return;
+    }
+
+    // Set icon size
+    if (newSlottedElement?.tagName.startsWith('JH-ICON')) {
+      newSlottedElement.setAttribute('size', 'medium');
+    }
+    
+    if (slot.name === 'jh-button-icon-left') {
+      this._hasLeftSlotContent = this.#checkSlotContent(slot);
+    } 
+    if (slot.name === 'jh-button-icon-right') {
+      this._hasRightSlotContent = this.#checkSlotContent(slot);
+    }
   }
+
+    #checkSlotContent(slot) {
+    // Slotted and fallback elements
+    const slottedElements = slot.assignedElements({ flatten: true });
+    if (slottedElements.length > 0) {
+        return true;
+    }
+    return false;
+}
 
   #renderButtonContent(pending, label) {
     let buttonContent;
@@ -889,13 +925,6 @@ export class JhButton extends LitElement {
     if (pending && !this.disabled) {
       buttonContent = html`
         <jh-progress type="circular" indeterminate></jh-progress>
-      `;
-    } else if (this.iconOnly) {
-      buttonContent = html`
-        <slot
-          name="jh-button-icon-left"
-          @slotchange=${this.#handleSlotChange}
-        ></slot>
       `;
     } else {
       buttonContent = html`
@@ -925,6 +954,7 @@ export class JhButton extends LitElement {
     if (this.href) {
       return html`
         <a
+          class=${classMap({ 'single-icon': !this.label && (this._hasLeftSlotContent !== this._hasRightSlotContent) })}
           tabindex="0"
           aria-disabled=${ifDefined(ariaDisabled)}
           aria-label=${ifDefined(this.accessibleLabel)}
@@ -938,6 +968,7 @@ export class JhButton extends LitElement {
     } else {
       return html`
         <button
+          class=${classMap({ 'single-icon': !this.label && (this._hasLeftSlotContent !== this._hasRightSlotContent) })}
           tabindex="0"
           aria-disabled=${ifDefined(ariaDisabled)}
           aria-label=${ifDefined(this.accessibleLabel)}

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -4,7 +4,6 @@
 
 import { LitElement, css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-import { classMap } from 'lit/directives/class-map.js';
 import '../progress/progress.js';
 
 /**
@@ -946,6 +945,7 @@ export class JhButton extends LitElement {
   render() {
     const buttonContent = this.#renderButtonContent(this.pending, this.label);
     let ariaDisabled;
+    let singleIconClass = !this.label && (this._hasLeftSlotContent !== this._hasRightSlotContent) ? 'single-icon' : null;
 
     if (this.accessibleDisabled !== 'false') {
       ariaDisabled = this.accessibleDisabled;
@@ -954,7 +954,7 @@ export class JhButton extends LitElement {
     if (this.href) {
       return html`
         <a
-          class=${classMap({ 'single-icon': !this.label && (this._hasLeftSlotContent !== this._hasRightSlotContent) })}
+          class=${ifDefined(singleIconClass)}
           tabindex="0"
           aria-disabled=${ifDefined(ariaDisabled)}
           aria-label=${ifDefined(this.accessibleLabel)}
@@ -968,7 +968,7 @@ export class JhButton extends LitElement {
     } else {
       return html`
         <button
-          class=${classMap({ 'single-icon': !this.label && (this._hasLeftSlotContent !== this._hasRightSlotContent) })}
+          class=${ifDefined(singleIconClass)}
           tabindex="0"
           aria-disabled=${ifDefined(ariaDisabled)}
           aria-label=${ifDefined(this.accessibleLabel)}

--- a/packages/jh-elements/components/button/button.mdx
+++ b/packages/jh-elements/components/button/button.mdx
@@ -28,8 +28,8 @@ import '@jack-henry/jh-elements/components/button/button.js';
 To use `jh-button`, set properties and slot icon within corresponding slot.
 
 ```html
-<jh-button icon-position="after">
-  <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+<jh-button label="Label">
+  <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
 </jh-button>
 ```
 

--- a/packages/jh-elements/components/button/button.stories.js
+++ b/packages/jh-elements/components/button/button.stories.js
@@ -7,6 +7,7 @@ import { action } from '@storybook/addon-actions';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import './button.js';
 import '@jack-henry/jh-icons/icons-wc/icon-ellipsis.js';
+import '@jack-henry/jh-icons/icons-wc/icon-chevron-down-small.js';
 
 const storyStyles = css`
   div[id^="story-root"] {
@@ -34,7 +35,7 @@ const disableControls = {
   size: { control: { disable: true } },
   submit: { control: { disable: true } },
   target: { control: { disable: true } },
-  'icon-position': { control: { disable: true } },
+  'icon-only': { control: { disable: true } },
   value: { table: { disable: true } },
 };
 
@@ -42,9 +43,8 @@ export default {
   component: 'jh-button',
   title: 'Components/Button',
   argTypes: {
-    'icon-position': {
-      control: 'select',
-      options: ['before', 'after'],
+    'icon-only': {
+      control: 'boolean',
     },
     appearance: {
       control: 'select',
@@ -90,14 +90,22 @@ export const Overview = {
   render: (args) => html`
     <div class="overview-row">
       <jh-button label="Label"></jh-button>
-      <jh-button icon-position="before" label="Label">
-        <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+      <jh-button label="Label">
+        <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
       </jh-button>
-      <jh-button icon-position="after" label="Label">
-        <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+      <jh-button label="Label">
+        <jh-icon-ellipsis slot="jh-button-icon-right"></jh-icon-ellipsis>
       </jh-button>
-      <jh-button accessible-label="label">
-        <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+      <jh-button label="Label">
+        <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+        <jh-icon-chevron-down-small slot="jh-button-icon-right"></jh-icon-chevron-down-small>
+      </jh-button>
+      <jh-button>
+        <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+        <jh-icon-chevron-down-small slot="jh-button-icon-right"></jh-icon-chevron-down-small>
+      </jh-button>
+      <jh-button accessible-label="label" icon-only>
+        <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
       </jh-button>
     </div>
   `,
@@ -130,9 +138,9 @@ export const Playground = {
     size=${args.size}
     ?submit=${args.submit}
     target=${ifDefined(args.target ? args.target : null)}
-    icon-position=${args['icon-position']}
+    ?icon-only=${args['icon-only']}
     label=${ifDefined(args.label || args.label !== '' ? args.label : null)}>
-    <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+    <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
   </jh-button>`,
 };
 
@@ -148,7 +156,7 @@ Playground.args = {
   size: 'medium',
   submit: false,
   target: null,
-  'icon-position': 'after',
+  'icon-only': false,
 };
 
 Playground.argTypes = {
@@ -163,8 +171,8 @@ Playground.parameters = {
 
 export const Block = {
   render: (args) => html`
-  <jh-button block label="Block" icon-position="before">
-    <jh-icon-ellipsis slot="jh-button-icon"></jh-icon-ellipsis>
+  <jh-button block label="Block">
+    <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
   </jh-button>`,
 };
 
@@ -225,5 +233,5 @@ FormAssociated.argTypes = {
   pending: { table: { disable: true } },
   size: { table: { disable: true } },
   target: { table: { disable: true } },
-  'icon-position': { table: { disable: true } },
+  'icon-only': { table: { disable: true } },
 };

--- a/packages/jh-elements/components/button/button.stories.js
+++ b/packages/jh-elements/components/button/button.stories.js
@@ -35,7 +35,6 @@ const disableControls = {
   size: { control: { disable: true } },
   submit: { control: { disable: true } },
   target: { control: { disable: true } },
-  'icon-only': { control: { disable: true } },
   value: { table: { disable: true } },
 };
 
@@ -43,9 +42,6 @@ export default {
   component: 'jh-button',
   title: 'Components/Button',
   argTypes: {
-    'icon-only': {
-      control: 'boolean',
-    },
     appearance: {
       control: 'select',
       options: ['primary', 'secondary', 'tertiary', 'danger'],
@@ -104,8 +100,11 @@ export const Overview = {
         <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
         <jh-icon-chevron-down-small slot="jh-button-icon-right"></jh-icon-chevron-down-small>
       </jh-button>
-      <jh-button accessible-label="label" icon-only>
+      <jh-button accessible-label="label">
         <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+      </jh-button>
+      <jh-button accessible-label="label">
+        <jh-icon-ellipsis slot="jh-button-icon-right"></jh-icon-ellipsis>
       </jh-button>
     </div>
   `,
@@ -138,9 +137,9 @@ export const Playground = {
     size=${args.size}
     ?submit=${args.submit}
     target=${ifDefined(args.target ? args.target : null)}
-    ?icon-only=${args['icon-only']}
     label=${ifDefined(args.label || args.label !== '' ? args.label : null)}>
     <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+    <jh-icon-chevron-down-small slot="jh-button-icon-right"></jh-icon-chevron-down-small>
   </jh-button>`,
 };
 
@@ -156,7 +155,6 @@ Playground.args = {
   size: 'medium',
   submit: false,
   target: null,
-  'icon-only': false,
 };
 
 Playground.argTypes = {
@@ -180,6 +178,71 @@ Block.argTypes = {
   ...disableControls,
 };
 
+export const IconsOnly = {
+  render: (args) => html`
+    <jh-button accessible-label="Left icon" 
+        ?block=${args.block}
+    ?disabled=${args.disabled}
+        ?pending=${args.pending}
+    size=${args.size}
+        label=${ifDefined(args.label || args.label !== '' ? args.label : null)}>
+      <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+    </jh-button>
+    <jh-button accessible-label="Right icon"
+        ?block=${args.block}
+    ?disabled=${args.disabled}
+        ?pending=${args.pending}
+    size=${args.size}
+        label=${ifDefined(args.label || args.label !== '' ? args.label : null)}>
+      <jh-icon-ellipsis slot="jh-button-icon-right"></jh-icon-ellipsis>
+    </jh-button>
+    <jh-button accessible-label="Both icons"
+        ?block=${args.block}
+    ?disabled=${args.disabled}
+        ?pending=${args.pending}
+    size=${args.size}
+        label=${ifDefined(args.label || args.label !== '' ? args.label : null)}>
+      <jh-icon-ellipsis slot="jh-button-icon-left"></jh-icon-ellipsis>
+      <jh-icon-chevron-down-small slot="jh-button-icon-right"></jh-icon-chevron-down-small>
+    </jh-button>
+  `,
+};
+
+IconsOnly.args = {
+  block: false,
+  disabled: false,
+  label: null,
+  pending: false,
+  size: 'medium',
+};
+
+IconsOnly.argTypes = {  appearance: { control: { disable: true } },
+  'accessible-disabled': { control: { disable: true } },
+  'accessible-label': { control: { disable: true } },
+  formAssociated: { table: { disable: true } },
+  href: { control: { disable: true } },
+  name: { control: { disable: true } },
+  submit: { control: { disable: true } },
+  target: { control: { disable: true } },
+  value: { table: { disable: true } },
+};
+
+IconsOnly.parameters = {
+  styles: storyStyles,
+};
+
+/**
+ * Handle a form submit event and log the action but don't actually submit the form
+ */
+function submitAction() {
+  const onSubmit = action('onSubmit');
+  const onFormdata = action('onFormdata');
+  return (event) => {
+    event.preventDefault();
+    onFormdata([...new FormData(event.target)]);
+    onSubmit(event);
+  };
+}
 export const FormAssociated = {
   render: (args) => {
     const onClick = (event) =>
@@ -203,19 +266,6 @@ export const FormAssociated = {
   },
 };
 
-/**
- * Handle a form submit event and log the action but don't actually submit the form
- */
-function submitAction() {
-  const onSubmit = action('onSubmit');
-  const onFormdata = action('onFormdata');
-  return (event) => {
-    event.preventDefault();
-    onFormdata([...new FormData(event.target)]);
-    onSubmit(event);
-  };
-}
-
 FormAssociated.args = {
   'accessible-disabled': false,
   disabled: false,
@@ -233,5 +283,6 @@ FormAssociated.argTypes = {
   pending: { table: { disable: true } },
   size: { table: { disable: true } },
   target: { table: { disable: true } },
-  'icon-only': { table: { disable: true } },
 };
+
+

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -120,10 +120,10 @@ export class JhInputPassword extends JhInput {
             ? html`
                 <slot
                   name="jh-input-password-visible"
-                  slot="jh-button-icon"
+                  slot="jh-button-icon-left"
                 >
                   <jh-icon-eye-slash
-                    slot="jh-button-icon"
+                    slot="jh-button-icon-left"
                     aria-hidden="true"
                     size="medium"
                   ></jh-icon-eye-slash>
@@ -132,10 +132,10 @@ export class JhInputPassword extends JhInput {
             : html`
                 <slot
                   name="jh-input-password-hidden"
-                  slot="jh-button-icon"
+                  slot="jh-button-icon-left"
                 >
                   <jh-icon-eye
-                    slot="jh-button-icon"
+                    slot="jh-button-icon-left"
                     aria-hidden="true"
                     size="medium"
                   ></jh-icon-eye>

--- a/packages/jh-elements/components/input/input.js
+++ b/packages/jh-elements/components/input/input.js
@@ -1149,8 +1149,8 @@ export class JhInput extends LitElement {
         size="small" appearance="tertiary" class="clear-button" 
         accessible-label=${ifDefined(this.accessibleLabelClearButton)}
         @click=${this._handleClearButtonClick}>
-        <slot name="jh-input-clear-button" slot="jh-button-icon">
-          <jh-icon-circle-xmark slot="jh-button-icon" aria-hidden="true" size="medium"></jh-icon-circle-xmark>
+        <slot name="jh-input-clear-button" slot="jh-button-icon-left">
+          <jh-icon-circle-xmark slot="jh-button-icon-left" aria-hidden="true" size="medium"></jh-icon-circle-xmark>
         </slot>
       </jh-button>
     `;

--- a/packages/jh-elements/components/input/input.stories.js
+++ b/packages/jh-elements/components/input/input.stories.js
@@ -270,7 +270,7 @@ export const Slots = {
     accessible-label-clear-button=${ifDefined(
     args['accessible-label-clear-button'] === ''
       ? null
-      : args['accessible-label-clear-button'])}><jh-icon-magnifying-glass slot="jh-input-left"></jh-icon-magnifying-glass><jh-button appearance="tertiary" slot="jh-input-right"><jh-icon-id-card slot="jh-button-icon"></jh-icon-id-card></jh-button></jh-input>
+      : args['accessible-label-clear-button'])}><jh-icon-magnifying-glass slot="jh-input-left"></jh-icon-magnifying-glass><jh-button appearance="tertiary" slot="jh-input-right"><jh-icon-id-card slot="jh-button-icon-left"></jh-icon-id-card></jh-button></jh-input>
 `,
 };
 

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -305,8 +305,8 @@ export class JhNotification extends LitElement {
           appearance="secondary"
           accessible-label=${this.dismissButtonAccessibleLabel}
           @click=${this.#handleDismissal}
-          ><slot name="jh-notification-dismiss-icon" slot="jh-button-icon">
-            <jh-icon-xmark slot="jh-button-icon"></jh-icon-xmark>
+          ><slot name="jh-notification-dismiss-icon" slot="jh-button-icon-left">
+            <jh-icon-xmark slot="jh-button-icon-left"></jh-icon-xmark>
           </slot>
         </jh-button>
       `;

--- a/packages/jh-elements/components/tag/tag.js
+++ b/packages/jh-elements/components/tag/tag.js
@@ -380,8 +380,8 @@ export class JhTag extends LitElement {
         appearance="secondary"
         accessible-label=${this.dismissButtonAccessibleLabel}
         @click=${this.#handleDismissal}>
-        <slot name="jh-tag-dismiss-icon" slot="jh-button-icon">
-          <jh-icon-xmark slot="jh-button-icon"></jh-icon-xmark>
+        <slot name="jh-tag-dismiss-icon" slot="jh-button-icon-left">
+          <jh-icon-xmark slot="jh-button-icon-left"></jh-icon-xmark>
         </slot>
       </jh-button>
       `;

--- a/packages/jh-elements/components/tooltip/tooltip.stories.js
+++ b/packages/jh-elements/components/tooltip/tooltip.stories.js
@@ -82,21 +82,21 @@ export const Overview = {
           <span slot="jh-tooltip-content">top-start</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="top-center">
           <span slot="jh-tooltip-content">top-center</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="top-end">
           <span slot="jh-tooltip-content">top-end</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
       </div>
@@ -105,14 +105,14 @@ export const Overview = {
           <span slot="jh-tooltip-content">left</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="right">
           <span slot="jh-tooltip-content">right</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
       </div>
@@ -121,21 +121,21 @@ export const Overview = {
           <span slot="jh-tooltip-content">bottom-start</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="bottom-center">
           <span slot="jh-tooltip-content">bottom-center</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="bottom-end">
           <span slot="jh-tooltip-content">bottom-end</span>
           <jh-button icon-position="before" accessible-label="view more"
             ><jh-icon-ellipsis
-              slot="jh-button-icon"
+              slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
       </div>

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -85,10 +85,10 @@
           "type": "?string"
         },
         {
-          "name": "icon-position",
-          "description": "Sets location of icon in relation to the label.",
-          "type": "'before'|'after'",
-          "default": "\"before\""
+          "name": "icon-only",
+          "description": "Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot.",
+          "type": "boolean",
+          "default": "false"
         },
         {
           "name": "pending",
@@ -170,11 +170,11 @@
           "type": "?string"
         },
         {
-          "name": "iconPosition",
-          "attribute": "icon-position",
-          "description": "Sets location of icon in relation to the label.",
-          "type": "'before'|'after'",
-          "default": "\"before\""
+          "name": "iconOnly",
+          "attribute": "icon-only",
+          "description": "Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot.",
+          "type": "boolean",
+          "default": "false"
         },
         {
           "name": "pending",
@@ -224,8 +224,12 @@
       ],
       "slots": [
         {
-          "name": "jh-button-icon",
-          "description": "Use to insert an icon."
+          "name": "jh-button-icon-left",
+          "description": "Use to insert an icon on the left side of the button and for `icon-only` buttons."
+        },
+        {
+          "name": "jh-button-icon-right",
+          "description": "Use to insert an icon on the right side of the button."
         }
       ],
       "cssProperties": [
@@ -611,7 +615,7 @@
         },
         {
           "name": "--jh-button-size",
-          "description": "The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size=\"small\"`, `--jh-dimension-1200` when `size=\"medium\"`, and `--jh-dimension-1400` when `size=\"large\"`."
+          "description": "The button width of icon-only buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size=\"small\"`, `--jh-dimension-1200` when `size=\"medium\"`, and `--jh-dimension-1400` when `size=\"large\"`."
         }
       ]
     },
@@ -5251,7 +5255,7 @@
         {
           "name": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {
@@ -5320,7 +5324,7 @@
           "name": "disabled",
           "attribute": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -85,12 +85,6 @@
           "type": "?string"
         },
         {
-          "name": "icon-only",
-          "description": "Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot.",
-          "type": "boolean",
-          "default": "false"
-        },
-        {
           "name": "pending",
           "description": "Displays a progress indicator.",
           "type": "?boolean",
@@ -170,13 +164,6 @@
           "type": "?string"
         },
         {
-          "name": "iconOnly",
-          "attribute": "icon-only",
-          "description": "Displays an icon-only button using the icon placed in the `jh-button-icon-left` slot.",
-          "type": "boolean",
-          "default": "false"
-        },
-        {
           "name": "pending",
           "attribute": "pending",
           "description": "Displays a progress indicator.",
@@ -225,11 +212,11 @@
       "slots": [
         {
           "name": "jh-button-icon-left",
-          "description": "Use to insert an icon on the left side of the button and for `icon-only` buttons."
+          "description": "Use to insert an icon on the left side of the button and for single icon buttons."
         },
         {
           "name": "jh-button-icon-right",
-          "description": "Use to insert an icon on the right side of the button."
+          "description": "Use to insert an icon on the right side of the button and for single icon buttons."
         }
       ],
       "cssProperties": [
@@ -615,7 +602,7 @@
         },
         {
           "name": "--jh-button-size",
-          "description": "The button width of icon-only buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size=\"small\"`, `--jh-dimension-1200` when `size=\"medium\"`, and `--jh-dimension-1400` when `size=\"large\"`."
+          "description": "The button width of single icon buttons, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size=\"small\"`, `--jh-dimension-1200` when `size=\"medium\"`, and `--jh-dimension-1400` when `size=\"large\"`."
         }
       ]
     },

--- a/packages/jh-elements/docs/guides/extending.mdx
+++ b/packages/jh-elements/docs/guides/extending.mdx
@@ -141,7 +141,7 @@ export class ExtendJhSearch extends JhInputSearch {
     let leftSlot = this.shadowRoot.querySelector('slot[name=jh-input-left]')
 
     if (leftSlot.assignedElements().length === 0) {
-      this.innerHTML = `<jh-button slot="jh-input-left"><jh-icon-user slot="jh-button-icon"></jh-icon-user></jh-button>`;
+      this.innerHTML = `<jh-button slot="jh-input-left"><jh-icon-user slot="jh-button-icon-left"></jh-icon-user></jh-button>`;
     }
 
     leftSlot.addEventListener('click', () => {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- It adds support for icons on the left and right side of the button, so both icons can be used at the same time.
- It also updates the following components an stories that use buttons with icons, since the name of the icon-slot has changed:
  - input
  - notification
  - tag
  - tooltip stories

**Idea number or other reference :** 226

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

