### PR TITLE
[Toast] Removes appearances property

### DIFF
--- a/packages/jh-elements/components/toast/toast.js
+++ b/packages/jh-elements/components/toast/toast.js
@@ -74,8 +74,6 @@ export class JhToast extends LitElement {
 
   static get properties() {
     return {
-      /** Sets the background color of the toast to convey message connotation. */
-      appearance: { type: String, reflect: true },
       /** Adds an aria-label to the dismiss button to assist screen readers. */
       dismissButtonAccessibleLabel: {
         type: String,
@@ -94,8 +92,6 @@ export class JhToast extends LitElement {
     super();
     /** @type {number} */
     this.timeout = 5000;
-    /** @type {'positive'|'neutral'|'negative'} */
-    this.appearance = 'neutral';
     /** @type {string} */
     this.dismissButtonAccessibleLabel = null;
     /** @type {boolean} */
@@ -151,7 +147,7 @@ export class JhToast extends LitElement {
   render() {
     return html`
       <jh-notification
-        appearance=${this.appearance}
+        appearance="neutral"
         dismiss-button-accessible-label=${this.dismissButtonAccessibleLabel}
         ?hide-dismiss-button=${this.hideDismissButton}
         ?stacked=${this.stacked}>

--- a/packages/jh-elements/components/toast/toast.mdx
+++ b/packages/jh-elements/components/toast/toast.mdx
@@ -69,8 +69,6 @@ Additionally, authors can specify which types of changes to the live region shou
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria.
 The following success criteria are of concern:
 
-- [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html):
-  Color is not used as the only visual means of conveying information, indicating an action, prompting a response, or distinguishing a visual element.
 - [WCAG 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html): Except for captions and images of text, text can be resized without assistive technology up to 200 percent without loss of content or functionality.
 - [WCAG 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html):
   All functionality of the content is operable through a keyboard interface without requiring specific timings for individual keystrokes, except where the underlying function requires input that depends on the path of the user's movement and not just the endpoints.
@@ -111,7 +109,6 @@ The following success criteria are of concern:
 
 ### Author Guidance
 
-- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), ensure that information conveyed through the toast appearance is also available in text.
 - To satisfy [WCAG 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html) when slotting buttons within the action slot, ensure that the buttons are keyboard operable and can be activated via the `Spacebar` and `Enter` keys. Use of the `jh-button` component will also satisfy this success criterion.
 - To satisfy [WCAG 2.2.1 Timing Adjustable](https://www.w3.org/WAI/WCAG22/Understanding/timing-adjustable.html), when auto dismissing the toast, authors should provide a way for users to either: turn off or adjust the the time limit before encountering it, or provide users a way to extend the time limit by at least 20 seconds before the time expires.
 - To satisfy [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html) when slotting buttons within the action slot, ensure that the buttons contain focus visible styles to help users determine which element has keyboard focus. Use of the `jh-button` component will also satisfy this success criterion.

--- a/packages/jh-elements/components/toast/toast.stories.js
+++ b/packages/jh-elements/components/toast/toast.stories.js
@@ -29,7 +29,6 @@ const storyStyles = css`
 `;
 
 const disableAllControls = {
-  appearance: { control: false },
   'dismiss-button-accessible-label': { control: false },
   'hide-dismiss-button': { control: false },
   stacked: { control: false },
@@ -45,10 +44,6 @@ export default {
     },
   },
   argTypes: {
-    appearance: {
-      control: 'select',
-      options: ['neutral', 'positive', 'negative'],
-    },
     stacked: {
       control: 'boolean',
     },
@@ -93,7 +88,6 @@ Overview.parameters = {
 };
 
 const createNewToast = (
-  appearance,
   hideDismissButton,
   dismissButtonAccessibleLabel,
   timeout,
@@ -104,7 +98,6 @@ const createNewToast = (
   let liveRegion = story.querySelector('div.live-region');
 
   let toast = document.createElement('jh-toast');
-  toast.setAttribute('appearance', appearance);
   hideDismissButton
     ? toast.setAttribute('hide-dismiss-button', hideDismissButton)
     : null;
@@ -129,7 +122,6 @@ export const Playground = {
         existingToast[0].remove();
       }
       createNewToast(
-        args.appearance,
         args['hide-dismiss-button'],
         args['dismiss-button-accessible-label'],
         args.timeout,
@@ -154,7 +146,6 @@ export const Playground = {
 
 Playground.args = {
   timeout: 5000,
-  appearance: 'positive',
   'hide-dismiss-button': true,
   'dismiss-button-accessible-label': 'dismiss toast',
   stacked: false,

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5251,7 +5251,7 @@
         {
           "name": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {
@@ -5320,7 +5320,7 @@
           "name": "disabled",
           "attribute": "disabled",
           "description": "Disables the radio group and prevents all user interactions. May cause the group to be ignored by assistive technologies (AT).",
-          "type": "?Boolean",
+          "type": "boolean",
           "default": "false"
         },
         {
@@ -6758,12 +6758,6 @@
           "default": "5000"
         },
         {
-          "name": "appearance",
-          "description": "Sets the background color of the toast to convey message connotation.",
-          "type": "'positive'|'neutral'|'negative'",
-          "default": "\"neutral\""
-        },
-        {
           "name": "dismiss-button-accessible-label",
           "description": "Adds an aria-label to the dismiss button to assist screen readers.",
           "type": "string"
@@ -6788,13 +6782,6 @@
           "description": "Sets a timer, in milliseconds, to auto-dismiss the toast. To disable timeout, set to 0.",
           "type": "number",
           "default": "5000"
-        },
-        {
-          "name": "appearance",
-          "attribute": "appearance",
-          "description": "Sets the background color of the toast to convey message connotation.",
-          "type": "'positive'|'neutral'|'negative'",
-          "default": "\"neutral\""
         },
         {
           "name": "dismissButtonAccessibleLabel",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It removes the appearance property from jh-toast and always sets it to `neutral`. 
It updates the docs and stories accordingly.

**Idea number or other reference :** 264

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies