### PR TITLE
[Button] Updates to button sizes and related components

### DIFF
--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -863,17 +863,19 @@ export class JhButton extends LitElement {
     new ResizeObserver(this.#cacheButtonDimensions.bind(this)).observe(this);
   }
 
-  //if button size changes, adjust the size of the icon accordingly.
+  //if button size changes, adjust the size of the icons accordingly.
   updated(changedProperties) {
   if (changedProperties.has('size')) {
     const iconSize = this.size === 'x-small' ? 'x-small' : 'medium';
-    const slot = this.shadowRoot.querySelector('slot[name="jh-button-icon"]');
+    const slots = this.shadowRoot.querySelectorAll('slot');
+    slots.forEach(slot => {
     const icon = slot?.assignedElements({flatten: true})[0];
     if (icon) {
       icon.setAttribute('size', iconSize);
       }
-    }
+    });
   }
+}
   #cacheButtonDimensions() {
     const { width } = this.getBoundingClientRect();
 

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -102,7 +102,7 @@ import '../progress/progress.js';
  * @cssprop --jh-button-border-radius - The button container border-radius. Defaults to `--jh-border-radius-100`.
  * @cssprop --jh-button-opacity-disabled - The button container opacity when disabled. Defaults to `--jh-opacity-disabled`.
  * @cssprop --jh-button-color-focus - The button container outline when it receives keyboard focus. Defaults to `--jh-border-focus-color`.
- * @cssprop --jh-button-size - The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size="small"`, `--jh-dimension-1200` when `size="medium"`, and `--jh-dimension-1400` when `size="large"`. 
+ * @cssprop --jh-button-size - The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-600` when `size="x-small"`,`--jh-dimension-800` when `size="small"`, `--jh-dimension-1000` when `size="medium"`, and `--jh-dimension-1200` when `size="large"`. 
  *
  * @slot jh-button-icon - Use to insert an icon.
  * @customElement jh-button
@@ -179,17 +179,21 @@ export class JhButton extends LitElement {
         pointer-events: none;
       }
       /* Size styling ('medium' is default) */
+      :host([size='x-small']) button,
+      :host([size='x-small']) a {
+        height: var(--jh-button-size, var(--jh-dimension-600));
+      }
       :host([size='small']) button,
       :host([size='small']) a {
-        height: var(--jh-button-size, var(--jh-dimension-1000));
+        height: var(--jh-button-size, var(--jh-dimension-800));
       }
       :host([size='medium']) button,
       :host([size='medium']) a {
-        height: var(--jh-button-size, var(--jh-dimension-1200));
+        height: var(--jh-button-size, var(--jh-dimension-1000));
       }
       :host([size='large']) button,
       :host([size='large']) a {
-        height: var(--jh-button-size, var(--jh-dimension-1400));
+        height: var(--jh-button-size, var(--jh-dimension-1200));
       }
       /* appearance='primary' ('secondary' is default) */
       :host([appearance='primary']) button,
@@ -698,17 +702,21 @@ export class JhButton extends LitElement {
         flex-direction: row-reverse;
       }
       /* Icon only styling */
+      :host(:not([label])[size='x-small']) button,
+      :host(:not([label])[size='x-small']) a {
+        width: var(--jh-button-size, var(--jh-dimension-600));
+      }
       :host(:not([label])[size='small']) button,
       :host(:not([label])[size='small']) a {
-        width: var(--jh-button-size, var(--jh-dimension-1000));
+        width: var(--jh-button-size, var(--jh-dimension-800));
       }
       :host(:not([label])[size='medium']) button,
       :host(:not([label])[size='medium']) a {
-        width: var(--jh-button-size, var(--jh-dimension-1200));
+        width: var(--jh-button-size, var(--jh-dimension-1000));
       }
       :host(:not([label])[size='large']) button,
       :host(:not([label])[size='large']) a {
-        width: var(--jh-button-size, var(--jh-dimension-1400));
+        width: var(--jh-button-size, var(--jh-dimension-1200));
       }
       :host(:not([label])) button,
       :host(:not([label])) a {
@@ -824,7 +832,7 @@ export class JhButton extends LitElement {
     this.label = null;
     /** @type {?string} */
     this.name = null;
-    /** @type {'small'|'medium'|'large'} */
+    /** @type {'x-small'|'small'|'medium'|'large'} */
     this.size = 'medium';
     /** @type {?boolean} */
     this.submit = false;
@@ -856,6 +864,17 @@ export class JhButton extends LitElement {
     new ResizeObserver(this.#cacheButtonDimensions.bind(this)).observe(this);
   }
 
+  //if button size changes, adjust the size of the icon accordingly.
+  updated(changedProperties) {
+  if (changedProperties.has('size')) {
+    const iconSize = this.size === 'x-small' ? 'x-small' : 'medium';
+    const slot = this.shadowRoot.querySelector('slot[name="jh-button-icon"]');
+    const icon = slot?.assignedElements({flatten: true})[0];
+    if (icon) {
+      icon.setAttribute('size', iconSize);
+      }
+    }
+  }
   #cacheButtonDimensions() {
     const { width } = this.getBoundingClientRect();
 
@@ -883,9 +902,17 @@ export class JhButton extends LitElement {
     }
   }
 
-  #handleSlotChange() {
-    this.firstElementChild.setAttribute('aria-hidden', 'true');
-    this.firstElementChild.setAttribute('size', 'medium');
+  #handleSlotChange(e) {
+    const icon = e.target.assignedElements({flatten: true})[0];
+    if (!icon) return;
+
+    icon.setAttribute('aria-hidden', 'true');
+
+    if (this.size === 'x-small') {
+      icon.setAttribute('size', 'x-small');
+    } else {
+      icon.setAttribute('size', 'medium');
+    }
   }
 
   #renderButtonContent(pending, label) {
@@ -898,7 +925,7 @@ export class JhButton extends LitElement {
 
     if (pending && !this.disabled) {
       buttonContent = html`
-        <jh-progress type="circular" indeterminate></jh-progress>
+        <jh-progress type="circular" indeterminate size=${this.size === 'x-small' ? 'small' : 'medium'}></jh-progress>
       `;
     } else {
       buttonContent = html`

--- a/packages/jh-elements/components/button/button.mdx
+++ b/packages/jh-elements/components/button/button.mdx
@@ -52,6 +52,12 @@ Buttons will act as a link if a hyperlink is set via the `href` property.
 - Link buttons can only be activated via the 'Enter' key.
 - Set the `target` property to specify where to display the linked URL.
 
+## X-small buttons
+
+- Use x-small buttons when a button is nested within another component and the other button sizes are too big, such as in `jh-input`.
+- X-small buttons should never be used on their own outside of another component.
+- X-small buttons use x-small icons, while the other button sizes use medium size icons.
+
 ## Pending state
 
 Set a pending state to indicate a process is underway, such as saving a record or submitting a form. The pending state will replace the button’s contents with a progress indicator and retain its width.

--- a/packages/jh-elements/components/button/button.stories.js
+++ b/packages/jh-elements/components/button/button.stories.js
@@ -52,7 +52,7 @@ export default {
     },
     size: {
       control: 'select',
-      options: ['small', 'medium', 'large'],
+      options: ['x-small','small', 'medium', 'large'],
     },
     block: {
       control: 'boolean',

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -120,7 +120,7 @@ renderInput() {
     let passwordBtn = html`
         <jh-button
           class="password-toggle-btn"
-          size="small"
+          size="x-small"
           appearance="tertiary"
           ?disabled=${this.disabled}
           accessible-label=${accessibleLabel}
@@ -135,7 +135,7 @@ renderInput() {
                   <jh-icon-eye-slash
                     slot="jh-button-icon"
                     aria-hidden="true"
-                    size="medium"
+                    size="x-small"
                   ></jh-icon-eye-slash>
                 </slot>
               `
@@ -147,7 +147,7 @@ renderInput() {
                   <jh-icon-eye
                     slot="jh-button-icon"
                     aria-hidden="true"
-                    size="medium"
+                    size="x-small"
                   ></jh-icon-eye>
                 </slot>
               `}

--- a/packages/jh-elements/components/input-search/input-search.js
+++ b/packages/jh-elements/components/input-search/input-search.js
@@ -36,7 +36,7 @@ export class JhInputSearch extends JhInput {
     
     return html`
       <slot name="jh-input-left" @slotchange=${this._handleSlotChange}>
-        <jh-icon-magnifying-glass aria-hidden="true"></jh-icon-magnifying-glass>
+        <jh-icon-magnifying-glass aria-hidden="true" size="x-small"></jh-icon-magnifying-glass>
       </slot>
     `;
   }

--- a/packages/jh-elements/components/input/input.js
+++ b/packages/jh-elements/components/input/input.js
@@ -117,7 +117,6 @@ export class JhInput extends LitElement {
         line-height: var(--input-helper-regular-line-height);
         display: inline-block;
         width: 100%;
-        --jh-button-size: var(--jh-dimension-800);
         --input-value-color-text: var(
           --jh-input-value-color-text,
           var(--jh-color-content-primary-enabled)
@@ -178,13 +177,13 @@ export class JhInput extends LitElement {
 
       /* Sizes on input wrapper */
       :host([size='small']) .input-wrapper {
-        height: var(--jh-dimension-1000);
+        height: var(--jh-dimension-800);
       }
       :host([size='medium']) .input-wrapper {
-        height: var(--jh-dimension-1200);
+        height: var(--jh-dimension-1000);
       }
       :host([size='large']) .input-wrapper {
-        height: var(--jh-dimension-1400);
+        height: var(--jh-dimension-1200);
       }
 
       /* Input element — no border, grows to fill */
@@ -1122,9 +1121,9 @@ export class JhInput extends LitElement {
     let hasContent = this.#checkSlotContent(slot);
     slot.classList.toggle('display-slot', hasContent);
 
-    // Set icon size if applicable
-    if (newSlottedElement?.tagName.startsWith('JH-ICON')) {
-      newSlottedElement.setAttribute('size', 'medium');
+    // Set jh-icon or jh-button size if applicable
+    if (newSlottedElement?.tagName.startsWith('JH-ICON')||newSlottedElement?.tagName === 'JH-BUTTON') {
+      newSlottedElement.setAttribute('size', 'x-small');
     }
   }
 
@@ -1146,11 +1145,11 @@ export class JhInput extends LitElement {
     if (!this.showClearButton || !this.value || this.disabled) return null;
     return html`
       <jh-button 
-        size="small" appearance="tertiary" class="clear-button" 
+        size="x-small" appearance="tertiary" class="clear-button" 
         accessible-label=${ifDefined(this.accessibleLabelClearButton)}
         @click=${this._handleClearButtonClick}>
         <slot name="jh-input-clear-button" slot="jh-button-icon">
-          <jh-icon-circle-xmark slot="jh-button-icon" aria-hidden="true" size="medium"></jh-icon-circle-xmark>
+          <jh-icon-circle-xmark slot="jh-button-icon"></jh-icon-circle-xmark>
         </slot>
       </jh-button>
     `;

--- a/packages/jh-elements/components/input/input.mdx
+++ b/packages/jh-elements/components/input/input.mdx
@@ -50,7 +50,7 @@ The input component makes use of both required compositional and suggested conte
 
 ## Slotting Buttons
 
-When slotting jh-button(s) within the `jh-input-left` or `jh-input-right` slots, consider setting `appearance="tertiary"` and `size="small"` for consistent styles across the input component. 
+When slotting jh-button(s) within the `jh-input-left` or `jh-input-right` slots, consider setting `appearance="tertiary"` for consistent styles across the input component. 
 
 ## Input Mask
 Utilize the `input-mask` attribute to assist users in formatting input values. As a user enters data into the input field, the value will be transformed to the specified format. 

--- a/packages/jh-elements/components/input/input.mdx
+++ b/packages/jh-elements/components/input/input.mdx
@@ -52,6 +52,8 @@ The input component makes use of both required compositional and suggested conte
 
 When slotting jh-button(s) within the `jh-input-left` or `jh-input-right` slots, consider setting `appearance="tertiary"` for consistent styles across the input component. 
 
+The buttons will automatically be set to `x-small` size when slotted. If extending the input component, ensure to set slot fallback buttons and icons to `x-small` to maintain consistent styles.
+
 ## Input Mask
 Utilize the `input-mask` attribute to assist users in formatting input values. As a user enters data into the input field, the value will be transformed to the specified format. 
 

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -205,6 +205,7 @@ export class JhNotification extends LitElement {
     .inline-container {
       display: flex;
       align-items: center;
+      line-height: 0;
     }
     `;
   }

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -136,7 +136,7 @@ export class JhNotification extends LitElement {
     }
     /* Default slot styling */
     .display-default-slot {
-      padding: var(--jh-dimension-200) 0;
+      padding: var(--jh-dimension-100) 0;
       margin: var(--jh-dimension-50) 0;
       font: var(--jh-font-body-regular-1);
       display: flex;
@@ -149,7 +149,7 @@ export class JhNotification extends LitElement {
     }
     slot[name="jh-notification-icon"]::slotted(*) {
       margin-right: var(--jh-dimension-400);
-      padding: var(--jh-dimension-200) 0;
+      padding: var(--jh-dimension-100) 0;
     }
     :host([appearance='neutral']) slot[name="jh-notification-icon"] {
       --jh-icon-color-fill: var(--jh-notification-icon-color-fill-neutral, var(--jh-color-content-on-primary-enabled));
@@ -204,7 +204,7 @@ export class JhNotification extends LitElement {
     .stacked-container,
     .inline-container {
       display: flex;
-      align-items: flex-start;
+      align-items: center;
     }
     `;
   }

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -295,6 +295,13 @@ export class JhNotification extends LitElement {
     }
   }
 
+  #handleIconSlotChange(e) {
+    let newSlottedElement = e.target.assignedElements()[0];
+    if (newSlottedElement?.tagName.startsWith('JH-ICON')) {
+      newSlottedElement.setAttribute('size', 'medium');
+    }
+  }
+
   render() {
     let dismissBtn;
     
@@ -314,7 +321,7 @@ export class JhNotification extends LitElement {
 
     return html`
       <div class=${this.stacked ? 'stacked-container' : 'inline-container'}>
-        <slot aria-hidden="true" name="jh-notification-icon"></slot>
+        <slot aria-hidden="true" name="jh-notification-icon" @slotchange=${this.#handleIconSlotChange}></slot>
         <slot @slotchange=${this.#handleSlotChange}></slot>
         ${this.stacked ? null : this.#getActionButtons()}
         ${dismissBtn}

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -323,8 +323,8 @@ export const Slots = {
       label=${args.label}
       .options=${args.options}
     >
-    <jh-button slot="jh-select-trigger-left">
-        <jh-icon-piggy-bank slot="jh-button-icon"></jh-icon-piggy-bank>
+    <jh-button slot="jh-select-trigger-left" size="x-small" appearance="tertiary">
+        <jh-icon-piggy-bank slot="jh-button-icon-left"></jh-icon-piggy-bank>
       </jh-button>
       <jh-icon-arrow-up-small slot="jh-select-trigger-open"></jh-icon-arrow-up-small>
       <jh-icon-arrow-down-small slot="jh-select-trigger-closed"></jh-icon-arrow-down-small>

--- a/packages/jh-elements/components/tag/tag.js
+++ b/packages/jh-elements/components/tag/tag.js
@@ -376,7 +376,7 @@ export class JhTag extends LitElement {
     if (this.dismissible) {
       dismissBtn = html`
       <jh-button
-        size="medium"
+        size="x-small"
         appearance="secondary"
         accessible-label=${this.dismissButtonAccessibleLabel}
         @click=${this.#handleDismissal}>

--- a/packages/jh-elements/components/tag/tag.js
+++ b/packages/jh-elements/components/tag/tag.js
@@ -388,7 +388,10 @@ export class JhTag extends LitElement {
     }
 
     if (this.dismissible && this.tooltipLabel) {
-      dismissBtn = html`<jh-tooltip label=${this.tooltipLabel}>${dismissBtn}</jh-tooltip>`;
+      dismissBtn = html`<jh-tooltip>
+        ${dismissBtn}
+        <div slot="jh-tooltip-content">${this.tooltipLabel}</div>
+      </jh-tooltip>`;
     }
     return dismissBtn;
   }

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -109,7 +109,7 @@
         {
           "name": "size",
           "description": "Sets the size of the button.",
-          "type": "'small'|'medium'|'large'",
+          "type": "'x-small'|'small'|'medium'|'large'",
           "default": "\"medium\""
         },
         {
@@ -199,7 +199,7 @@
           "name": "size",
           "attribute": "size",
           "description": "Sets the size of the button.",
-          "type": "'small'|'medium'|'large'",
+          "type": "'x-small'|'small'|'medium'|'large'",
           "default": "\"medium\""
         },
         {
@@ -611,7 +611,7 @@
         },
         {
           "name": "--jh-button-size",
-          "description": "The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-1000` when `size=\"small\"`, `--jh-dimension-1200` when `size=\"medium\"`, and `--jh-dimension-1400` when `size=\"large\"`."
+          "description": "The button width when no label is set, and the button height. Button width and height defaults to `--jh-dimension-600` when `size=\"x-small\"`,`--jh-dimension-800` when `size=\"small\"`, `--jh-dimension-1000` when `size=\"medium\"`, and `--jh-dimension-1200` when `size=\"large\"`."
         }
       ]
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

**Button**
- it adds the x-small size to jh-button. 
- it sets the size of icons inside x-small buttons to x-small. All other sizes have medium icons.
- it adjusts the sizing of the 3 existing size options down.

**Input**
- it adjusts down the sizing (height) of jh-input to match the new button sizing.
- it sets all icons and buttons in jh-input to x-small, including the clear button.

**Notification**
- it sets the size of the notification icon to medium.
- adjusts the padding on default slot text.

**Tag**
- it sets the tag dismiss button to x-small. 
- Note: tag still uses custom css for the size, but this allows us to set the icon in the dismiss button set to x-small automatically.
- extra bug fix: moves the dismiss tooltip text to the new tooltip slot (instead of label property)

**Idea number or other reference :** 188

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies
