### PR TITLE
[Next] Add manual-publish action and update composite action

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -9,20 +9,16 @@ runs:
   using: "composite"
   steps:
     - name: Install PNPM
-      uses: pnpm/action-setup@v2
+      uses: pnpm/action-setup@v4
       with:
         version: 8.5.1
 
     - name: Install Nodejs
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@v6
       with:
-        node-version: 18
-
-    - name: Output .npmrc
-      shell: bash
-      run: |
-        echo "registry=https://registry.npmjs.org/" > ~/.npmrc
-        echo "include-workspace-root: true" >> ~/.npmrc
+        node-version: 22
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
       
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -1,0 +1,43 @@
+name: Manual Publish
+on:
+  workflow_dispatch:
+    inputs:
+      package_filter:
+        description: 'Package name (e.g., @jack-henry/jh-ui) - use multiple --filter flags if needed'
+        required: true
+        default: '--filter @jack-henry/jh-ui'
+      tag:
+        description: 'NPM Tag (latest or beta)'
+        required: true
+        type: choice
+        options:
+          - latest
+          - beta
+        default: 'latest'
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read     # To checkout the code
+      id-token: write    # CRITICAL for OIDC handshake with npm
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Build
+        run: pnpm -r build
+
+      - name: Publish Specific Packages (DRY RUN)
+        run: pnpm $PACKAGE_FILTER publish --access public --no-git-checks --provenance --tag $NPM_TAG --dry-run
+        env:
+          PACKAGE_FILTER: ${{ github.event.inputs.package_filter }}
+          NPM_TAG: ${{ github.event.inputs.tag }}
+          NODE_AUTH_TOKEN: 'oidc-is-enabled'

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2026 Jack Henry
+#
+# SPDX-License-Identifier: Apache-2.0
+
 name: Manual Publish
 on:
   workflow_dispatch:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds a Github Action to use to publish our packages.
The package bump and release notes are still done manually.

**Idea number or other reference :** N/A

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Review action. We will be able to test the dry run version after we merge into Next.

## Notes/Dependencies

The same needs to be added to our other release branches.


