### PR TITLE
[V2] add manual publish Action to V2 branch

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -17,12 +17,8 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: 22
-
-    - name: Output .npmrc
-      shell: bash
-      run: |
-        echo "registry=https://registry.npmjs.org/" > ~/.npmrc
-        echo "include-workspace-root: true" >> ~/.npmrc
+        registry-url: 'https://registry.npmjs.org'
+        cache: 'pnpm'
       
     - name: Install dependencies
       shell: bash

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2026 Jack Henry
+#
+# SPDX-License-Identifier: Apache-2.0
+
+name: Manual Publish
+on:
+  workflow_dispatch:
+    inputs:
+      package_filter:
+        description: 'Package name (e.g., @jack-henry/jh-elements) - use multiple --filter flags if needed'
+        required: true
+        default: '--filter @jack-henry/jh-elements'
+      tag:
+        description: 'NPM Tag (latest or beta)'
+        required: true
+        type: choice
+        options:
+          - latest
+          - beta
+        default: 'latest'
+
+jobs:
+  publish:
+    name: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read     # To checkout the code
+      id-token: write    # CRITICAL for OIDC handshake with npm
+    
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install dependencies
+        uses: ./.github/workflows/actions/install-dependencies
+
+      - name: Build
+        run: pnpm -r build
+
+      - name: Publish Specific Packages (DRY RUN)
+        run: pnpm $PACKAGE_FILTER publish --access public --no-git-checks --provenance --tag $NPM_TAG --dry-run
+        env:
+          PACKAGE_FILTER: ${{ github.event.inputs.package_filter }}
+          NPM_TAG: ${{ github.event.inputs.tag }}
+          NODE_AUTH_TOKEN: 'oidc-is-enabled'

--- a/packages/jh-elements/package.json
+++ b/packages/jh-elements/package.json
@@ -35,6 +35,7 @@
     "lit": "3.3.1"
   },
   "devDependencies": {
+    "@jack-henry/jh-datasets": "workspace:2.0.0-beta.1",
     "@storybook/addon-a11y": "8.6.17",
     "@storybook/addon-actions": "8.6.17",
     "@storybook/addon-essentials": "8.6.17",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2025 Jack Henry
+#
+# SPDX-License-Identifier: Apache-2.0
+
 lockfileVersion: '6.0'
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Jack Henry
-#
-# SPDX-License-Identifier: Apache-2.0
-
 lockfileVersion: '6.0'
 
 importers:
@@ -29,6 +25,9 @@ importers:
         specifier: 3.3.1
         version: 3.3.1
     devDependencies:
+      '@jack-henry/jh-datasets':
+        specifier: workspace:2.0.0-beta.1
+        version: link:../jh-datasets
       '@storybook/addon-a11y':
         specifier: 8.6.17
         version: 8.6.17(storybook@8.6.17)


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds the Github Action to publish to V2.

Also added missing `jh-datasets` to devDependencies of `jh-elements`.

**Idea number or other reference :** N/A

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Review Action. We will test once merged.

## Notes/Dependencies

- remove Dry run flag after testing.


