### PR TITLE
Updates next branch migration docs

### DIFF
--- a/packages/jh-ui/docs/whats-new/jh-elements.mdx
+++ b/packages/jh-ui/docs/whats-new/jh-elements.mdx
@@ -129,6 +129,10 @@ A multi-line text field for longer text input.
 
 A single-line text field for URL entry.
 
+### jh-select
+
+A non-editable single select dropdown component that displays a list of options. The `jh-select` component integrates seamlessly with the `jh-datasets` package, allowing you to quickly populate the menu with pre-formatted datasets like US states without manually structuring the data.
+
 ### jh-table
 
 An enhanced HTML table component, which includes sorting hooks, and all its supcomponents:

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -485,7 +485,10 @@ The default width of `jh-switch` has been reduced from 56px to 48px. Users shoul
 
 The label font family, weight, size and line height tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...` to ensure consistent styling across form controls.  
 
-### jh-tooltip
+### Migrating jh-toast
+The `appearance` property has been deprecated. The component now uses a single, neutral default color for all instances.
+
+### Migrating jh-tooltip
 The `label` property has been deprecated. Users should move label text content to the `jh-tooltip-content` slot. The typography tokens have changed from `--jh-font-helper-regular-...` to `--jh-font-helper-bold-...`.
 
 ## Migrating jh-icons

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -70,14 +70,18 @@ Package Changes:
 *  `jh-core` is renamed to `jh-tokens`: Contains all global and alias design tokens for the system as well as light and dark themes.
 * The `jh-tokens` package no longer includes the font files. They are now available in the assets/fonts folder at the project root directory. 
 
-New Packages (Coming Soon):
+New Packages:
 
-* `jh-element`: A base class that all design system components extend off.
-* `jh-validate`: Introduces our form validation mixin.
+* `jh-datasets`: Provides a set of common datasets that can be used with our components. 
+* `jh-validate`: Introduces our form validation mixin (coming Soon).
 
 ## Developer experience
 
 DX was a major focus of this release and we introduce a number of enhancements and new packages to help authors quickly build high quality applications.
+
+### jh-datasets package
+
+Provides a collection of common datasets and utilities for use with design system components, such as `jh-select`. Includes pre-built datasets such as US states (available in flat and grouped formats) and a `manageDataset` utility to process datasets with initial values and disabled items.
 
 ### jh-validate package (coming soon)
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the migration docs:

- Adds `jh-datasets` package.
- Adds `jh-select` component. 
- Adds removal of `toast` `appearance` property. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a