### PR TITLE
[Next] remove dry run from manual publish action

### DIFF
--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -39,8 +39,8 @@ jobs:
       - name: Build
         run: pnpm -r build
 
-      - name: Publish Specific Packages (DRY RUN)
-        run: pnpm $PACKAGE_FILTER publish --access public --no-git-checks --provenance --tag $NPM_TAG --dry-run
+      - name: Publish Specific Packages
+        run: pnpm $PACKAGE_FILTER publish --access public --no-git-checks --provenance --tag $NPM_TAG
         env:
           PACKAGE_FILTER: ${{ github.event.inputs.package_filter }}
           NPM_TAG: ${{ github.event.inputs.tag }}


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It removes the dry-run flag from the manual publish action after testing.

**Idea number or other reference :**

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Check the dry run flag was removed.

## Notes/Dependencies

N/A


