### PR TITLE
bump jh-elements package to v.2.0.0-beta.13

### DIFF
--- a/packages/jh-elements/package.json
+++ b/packages/jh-elements/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@jack-henry/jh-elements",
   "description": "Jack Henry's design system web components.",
-  "version": "2.0.0-beta.12",
+  "version": "2.0.0-beta.13",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/Banno/jack-henry-design-system.git"


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It bumps the jh-elements package to v.2.0.0-beta.13.

**Idea number or other reference :** N/A

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [x] Other (add details below)

**Additional Details**

Check version number

## Notes/Dependencies

N/A