### PR TITLE
Enable Storybook experimentalComponentsManifest feature

### DIFF
--- a/packages/jh-ui/.storybook/main.js
+++ b/packages/jh-ui/.storybook/main.js
@@ -14,6 +14,9 @@ const config = {
   docs: {
     autodocs: true,
   },
+  features: {
+    experimentalComponentsManifest: true,
+  },
   framework: {
     name: '@storybook/web-components-vite',
     options: {}


### PR DESCRIPTION
## Summary

- Adds `features: { experimentalComponentsManifest: true }` to `packages/jh-ui/.storybook/main.js`

## Why

This enables Storybook to generate `manifests/components.json` and `manifests/docs.json` as part of the build. These static files expose component metadata (stories, prop types from the Custom Elements Manifest, and MDX documentation content) in a machine-readable format.

With this enabled, AI agents connected to the Banno federated Storybook via the Storybook MCP addon will be able to discover and query `jh-ui` components — including their props, stories, and written docs — without hallucinating API details.

## Why not install `@storybook/addon-mcp`?

This repo is on **Storybook 8.6**. The `@storybook/addon-mcp` package requires Storybook 9.1.16+, so it cannot be installed here. Fortunately, `experimentalComponentsManifest` was backported to Storybook 8 core — the feature flag alone is sufficient to generate the manifest files at build time without the addon.

Note: This repo already publishes a `custom-elements.json` CEM file (the `"customElements"` field in `packages/jh-ui/package.json`), which means the generated manifest will include component properties, attributes, events, and slots automatically.

When this repo upgrades to Storybook 9+, rename the flag to `componentsManifest` and optionally install `@storybook/addon-mcp` to also get the local MCP server endpoint.

## Test plan

- [ ] Run `storybook build` in `packages/jh-ui` and confirm `storybook-static/manifests/components.json` is generated
- [ ] Open `manifests/components.json` and verify component entries include `attributes`, `events`, and `slots` data sourced from `custom-elements.json`
- [ ] Confirm `storybook-static/manifests/docs.json` is generated
- [ ] Verify no regressions in existing Storybook stories