### PR TITLE
[jh-datasets] new package bootstrap version

### DIFF
--- a/packages/jh-datasets/README.md
+++ b/packages/jh-datasets/README.md
@@ -1,0 +1,11 @@
+<!--
+SPDX-FileCopyrightText: 2026 Jack Henry
+
+SPDX-License-Identifier: Apache-2.0
+-->
+
+## @jack-henry/jh-datasets
+
+Contains Jack Henry's frequently used datasets that work with compatible components like `jh-select`. To get started, visit our documentation site:
+
+* [jh-datasets on Storybook](https://release-v2--68f8e6a25b256d0ef89b13e6.chromatic.com/?path=/docs/guides-datasets-package--docs)

--- a/packages/jh-datasets/package.json
+++ b/packages/jh-datasets/package.json
@@ -1,0 +1,25 @@
+  
+{
+  "name": "@jack-henry/jh-datasets",
+  "description": "Jack Henry datasets utility",
+  "version": "0.0.1",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Banno/jack-henry-design-system.git"
+  },
+  "contributors": [
+    "Audrey Bissiere-Grote",
+    "Brad McCormick",
+    "Maya Buser De"
+  ],
+  "license": "Apache-2.0",
+  "files": [
+    "utils",
+    "datasets",
+    "NOTICE"
+  ],
+  "scripts": {
+    "prepack": "cp ../../NOTICE .",
+    "postpack": "rm -f NOTICE"
+}
+}

--- a/packages/jh-datasets/package.json
+++ b/packages/jh-datasets/package.json
@@ -13,6 +13,7 @@
     "Maya Buser De"
   ],
   "license": "Apache-2.0",
+  "type": "module",
   "files": [
     "utils",
     "datasets",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,3 +1,6 @@
+# SPDX-FileCopyrightText: 2025 Jack Henry
+#
+# SPDX-License-Identifier: Apache-2.0
 lockfileVersion: '6.0'
 
 importers:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,7 +1,3 @@
-# SPDX-FileCopyrightText: 2025 Jack Henry
-#
-# SPDX-License-Identifier: Apache-2.0
-
 lockfileVersion: '6.0'
 
 importers:
@@ -14,6 +10,8 @@ importers:
       '@changesets/cli':
         specifier: 2.26.2
         version: 2.26.2
+
+  packages/jh-datasets: {}
 
   packages/jh-elements:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -6,3 +6,4 @@ packages:
 - 'packages/jh-elements'
 - 'packages/jh-tokens'
 - 'packages/jh-icons'
+- 'packages/jh-datasets'


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds a bootstrap version for the jh-datasets package for first manual publish.

**Idea number or other reference :** Select Phase 3

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Review package.json for initial publish

## Notes/Dependencies

This will be used to set up an initial version of the jh-datasets package. Then we will release through the Github Action as usual.