### PR TITLE
[jh-button] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -1009,5 +1009,4 @@ export class JhButton extends JhElement {
     }
   }
 }
-
-customElements.define('jh-button', JhButton);
+JhElement.register('jh-button', JhButton);

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -115,9 +115,6 @@ export class JhButton extends JhElement {
     return true;
   }
 
-  /** @type {ElementInternals} */
-  #internals;
-
   /** @type {?string} */
   #value;
 
@@ -807,9 +804,7 @@ export class JhButton extends JhElement {
   constructor() {
     super();
     /** @type {ElementInternals} */
-    this.#internals = this.attachInternals();
-    /** @type {ElementInternals} */
-    this.#internals.form;
+    this.internals.form;
     /** @type {'true'|'false'} */
     this.accessibleDisabled = null;
     /** @type {?string} */
@@ -854,7 +849,7 @@ export class JhButton extends JhElement {
     const oldValue = this.#value;
     if (newValue !== oldValue) {
       this.#value = newValue;
-      this.#internals.setFormValue(newValue);
+      this.internals.setFormValue(newValue);
     }
     this.requestUpdate('value', oldValue);
   }
@@ -889,8 +884,8 @@ export class JhButton extends JhElement {
 
   #onClick(event) {
     //If I'm a submit button in a form and I'm not disabled submit the form
-    if (this.submit && this.#internals.form && !this.disabled) {
-      this.#internals.form.requestSubmit();
+    if (this.submit && this.internals.form && !this.disabled) {
+      this.internals.form.requestSubmit();
     }
   }
 

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { JhElement } from '../element/element.js';
 import '../progress/progress.js';
 
 /**
@@ -108,7 +109,7 @@ import '../progress/progress.js';
  * @slot jh-button-icon-right - Use to insert an icon on the right side of the button and for single icon buttons.
  * @customElement jh-button
  */
-export class JhButton extends LitElement {
+export class JhButton extends JhElement {
   /** @ignore */
   static get formAssociated() {
     return true;

--- a/packages/jh-elements/components/button/button.js
+++ b/packages/jh-elements/components/button/button.js
@@ -1004,4 +1004,4 @@ export class JhButton extends JhElement {
     }
   }
 }
-JhElement.register('jh-button', JhButton);
+JhButton.register('jh-button', JhButton);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-button` to extend off of `jh-element` component. Changes include:

1. Component extends `jh-element`.
2. Updates `#internals` property to `jh-element` `internals` property.
3. Component definition replaced by `jh-element` `register` method. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-element` PR should be merged first. 


