### PR TITLE
[jh-card] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -342,4 +342,4 @@ export class JhCard extends JhElement {
     `;
   }
 }
-JhElement.register('jh-card', JhCard);
+JhCard.register('jh-card', JhCard);

--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -342,4 +342,4 @@ export class JhCard extends JhElement {
     `;
   }
 }
-customElements.define('jh-card', JhCard);
+JhElement.register('jh-card', JhCard);

--- a/packages/jh-elements/components/card/card.js
+++ b/packages/jh-elements/components/card/card.js
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { JhElement } from '../element/element.js';
 import '../divider/divider.js';
 
 /**
@@ -31,7 +32,7 @@ import '../divider/divider.js';
  * @slot jh-card-footer - Use to insert card footer content.
  * @customElement jh-card
  */
-export class JhCard extends LitElement {
+export class JhCard extends JhElement {
   static get styles() {
     return css`
       :host {
@@ -341,5 +342,4 @@ export class JhCard extends LitElement {
     `;
   }
 }
-
 customElements.define('jh-card', JhCard);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-card` to extend off of `jh-element` component. Changes include:

1. Component extends `jh-element`.
2. Component definition replaced by `jh-element` `register` method. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-element` PR should be merged first. 
