### PR TITLE
[jh-checkbox-group] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -25,9 +25,6 @@ let id = 0;
  * @customElement jh-checkbox-group
  */
 export class JhCheckboxGroup extends JhElement {
-  /** @type {?Number} */
-  #id;
-
   static get styles() {
     return css`
       :host {
@@ -212,11 +209,6 @@ export class JhCheckboxGroup extends JhElement {
     this.showIndicator = false;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   firstUpdated() {
     const slot = this.renderRoot?.querySelector('slot');
     this.#syncDisabledToChildren();
@@ -240,13 +232,13 @@ export class JhCheckboxGroup extends JhElement {
 
   #getAriaDescribedBy() {
     if (this.errorText && this.invalid && this.helperText && this.label) {
-      return `checkbox-group-error-${this.#id} checkbox-group-helper-${
-        this.#id
+      return `checkbox-group-error-${this.uniqueId} checkbox-group-helper-${
+        this.uniqueId
       }`;
     } else if (this.errorText && this.invalid) {
-      return `checkbox-group-error-${this.#id}`;
+      return `checkbox-group-error-${this.uniqueId}`;
     } else if (this.helperText && this.label) {
-      return `checkbox-group-helper-${this.#id}`;
+      return `checkbox-group-helper-${this.uniqueId}`;
     }
   }
 
@@ -265,24 +257,24 @@ export class JhCheckboxGroup extends JhElement {
     }
 
     if (this.helperText) {
-      helperText = html`<p class="helper-text" id="checkbox-group-helper-${this.#id}">${this.helperText}</p>`;
+      helperText = html`<p class="helper-text" id="checkbox-group-helper-${this.uniqueId}">${this.helperText}</p>`;
     }
 
     if (this.label) {
       label = html`
-        <legend class="label" for="checkbox-group-label-${this.#id}">
+        <legend class="label" for="checkbox-group-label-${this.uniqueId}">
           ${this.label}${indicator}
         </legend>
         ${helperText}`;
     }
 
     if (this.invalid && this.errorText) {
-      errorText = html`<p class="error-text" id="checkbox-group-error-${this.#id}">${this.errorText}</p>`;
+      errorText = html`<p class="error-text" id="checkbox-group-error-${this.uniqueId}">${this.errorText}</p>`;
     }
 
     return html`
       <fieldset
-        id=${ifDefined(this.label ? `checkbox-group-label-${this.#id}` : null)}
+        id=${ifDefined(this.label ? `checkbox-group-label-${this.uniqueId}` : null)}
         aria-describedby=${ifDefined(this.#getAriaDescribedBy())}
         ?required=${this.required}
         aria-invalid=${ifDefined(this.invalid ? 'true' : null)}

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -6,7 +6,6 @@ import { css, html } from 'lit';
 import { JhElement } from '../element/element.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
-let id = 0;
 /**
  *
  * @cssprop --jh-checkbox-group-label-color-text - The label text color. Defaults to `--jh-color-content-primary-enabled`.

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -287,4 +287,4 @@ export class JhCheckboxGroup extends JhElement {
     `;
   }
 }
-JhElement.register('jh-checkbox-group', JhCheckboxGroup);
+JhCheckboxGroup.register('jh-checkbox-group', JhCheckboxGroup);

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 let id = 0;
@@ -23,7 +24,7 @@ let id = 0;
  *
  * @customElement jh-checkbox-group
  */
-export class JhCheckboxGroup extends LitElement {
+export class JhCheckboxGroup extends JhElement {
   /** @type {?Number} */
   #id;
 

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -295,4 +295,4 @@ export class JhCheckboxGroup extends JhElement {
     `;
   }
 }
-customElements.define('jh-checkbox-group', JhCheckboxGroup);
+JhElement.register('jh-checkbox-group', JhCheckboxGroup);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -900,6 +900,10 @@
           "description": "Adds a visual indicator next to the label. Indicates that a value is optional (by default) or required if the `required` property is also set. For the indicator to be displayed, the `label` property must also be set.",
           "type": "?boolean",
           "default": "false"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "slots": [
@@ -1268,17 +1272,6 @@
         {
           "name": "--jh-divider-space-inset",
           "description": "The divider margin-left. Defaults to `0`."
-        }
-      ]
-    },
-    {
-      "name": "jh-element",
-      "path": "./components/element/element.js",
-      "description": "Element",
-      "properties": [
-        {
-          "name": "uniqueId",
-          "type": "number"
         }
       ]
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-checkbox-group` to extend off of `jh-element` component. Changes include:

1. Component extends `jh-element`.
2. Updates `#id` property to `jh-element` `uniqueId` property.
3. Component definition replaced by `jh-element` `register` method. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-element` PR should be merged first. 


