### PR TITLE
[jh-divider] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/divider/divider.js
+++ b/packages/jh-elements/components/divider/divider.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css } from 'lit';
+import { css } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-divider-border-width - The divider width. Defaults to `--jh-border-decorative-width`.
@@ -11,7 +12,7 @@ import { LitElement, css } from 'lit';
  * @cssprop --jh-divider-space-inset - The divider margin-left. Defaults to `0`.
  * @customElement jh-divider
  */
-export class JhDivider extends LitElement {
+export class JhDivider extends JhElement {
   static get styles() {
     return css`
         :host {

--- a/packages/jh-elements/components/divider/divider.js
+++ b/packages/jh-elements/components/divider/divider.js
@@ -88,5 +88,4 @@ export class JhDivider extends JhElement {
     this.inset = null;
   }
 }
-
-customElements.define('jh-divider', JhDivider);
+JhElement.register('jh-divider', JhDivider);

--- a/packages/jh-elements/components/divider/divider.js
+++ b/packages/jh-elements/components/divider/divider.js
@@ -88,4 +88,4 @@ export class JhDivider extends JhElement {
     this.inset = null;
   }
 }
-JhElement.register('jh-divider', JhDivider);
+JhDivider.register('jh-divider', JhDivider);

--- a/packages/jh-elements/components/divider/divider.js
+++ b/packages/jh-elements/components/divider/divider.js
@@ -68,7 +68,7 @@ export class JhDivider extends JhElement {
           margin-left: var(--inset, var(--jh-divider-space-inset));
         }
       `
-        }
+  }
 
   static get properties() {
     return {


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-divider` to extend off of `jh-element` component. Changes include:

1. Component extends `jh-element`.
2. Component definition replaced by `jh-element` `register` method. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-element` PR should be merged first. 

