### PR TITLE
[jh-icon] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -88,4 +88,4 @@ export class JhIcon extends JhElement {
     `;
   }
 }
-JhElement.register('jh-icon', JhIcon);
+JhIcon.register('jh-icon', JhIcon);

--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-icon-color-fill - The icon color. Defaults to `--jh-color-content-secondary-enabled`.
@@ -14,7 +15,7 @@ import { LitElement, css, html } from 'lit';
  * @slot default - Use to insert the icon SVG content.
  * @customElement jh-icon
  */
-export class JhIcon extends LitElement {
+export class JhIcon extends JhElement {
 
   /** @type {ElementInternals} */
   #internals;

--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -94,4 +94,4 @@ export class JhIcon extends JhElement {
     `;
   }
 }
-customElements.define('jh-icon', JhIcon);
+JhElement.register('jh-icon', JhIcon);

--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -16,10 +16,6 @@ import { JhElement } from '../element/element.js';
  * @customElement jh-icon
  */
 export class JhIcon extends JhElement {
-
-  /** @type {ElementInternals} */
-  #internals;
-
   static get styles() {
     return css`
       :host {
@@ -80,10 +76,8 @@ export class JhIcon extends JhElement {
   }
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'graphics-symbol';
-    this.#internals.ariaHidden = 'true';
-
+    this.internals.role = 'graphics-symbol';
+    this.internals.ariaHidden = 'true';
     /** @type {'x-small'|'small'|'medium'|'large'|'x-large'} */
     this.size = 'medium';
   }


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-icon` to extend off of `jh-element` component. Changes include:

1. Component extends `jh-element`.
2. Updates `#internals` property to `jh-element` `internals` property.
3. Component definition replaced by `jh-element` `register` method. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

N/A

## Notes/Dependencies

- `jh-element` PR should be merged first. 

