### PR TITLE
[jh-input-password] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -16,10 +16,6 @@ let id = 0;
  * @customElement jh-input-password
  */
 export class JhInputPassword extends JhInput {
-
-  /** @type {?number} */
-  #id;
-
   static get properties() {
     return {
       /** Unmasks the input field value when set. */
@@ -47,12 +43,7 @@ export class JhInputPassword extends JhInput {
     this.passwordVisible = false;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
-renderInput() {
+  renderInput() {
     let describedby;
 
     if (this.helperText || (this.errorText && this.invalid)) {
@@ -68,7 +59,7 @@ renderInput() {
         <div class="input-wrapper">
           ${leftSlot}
           <input
-            id="jh-input-${this.#id}"
+            id="jh-input-${this.uniqueId}"
             aria-describedby=${describedby}
             aria-invalid=${ifDefined(this.invalid ? 'true' : null)}
             aria-label=${ifDefined(

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -160,4 +160,4 @@ renderInput() {
     this.passwordVisible = !this.passwordVisible;
   }
 }
-customElements.define('jh-input-password', JhInputPassword);
+JhInputPassword.register('jh-input-password', JhInputPassword);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1272,17 +1272,6 @@
       ]
     },
     {
-      "name": "jh-element",
-      "path": "./components/element/element.js",
-      "description": "Element",
-      "properties": [
-        {
-          "name": "uniqueId",
-          "type": "number"
-        }
-      ]
-    },
-    {
       "name": "jh-icon",
       "path": "./components/icon/icon.js",
       "attributes": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-input-password` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.
2. Updates `#id` property to `jh-element` `uniqueId` property.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.


