### PR TITLE
[jh-progress] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/progress/progress.js
+++ b/packages/jh-elements/components/progress/progress.js
@@ -412,4 +412,4 @@ export class JhProgress extends JhElement {
   }
 }
 
-JhElement.register('jh-progress', JhProgress);
+JhProgress.register('jh-progress', JhProgress);

--- a/packages/jh-elements/components/progress/progress.js
+++ b/packages/jh-elements/components/progress/progress.js
@@ -2,8 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-progress-label-color - The label text color. Defaults to `--jh-color-content-primary-enabled`.
@@ -13,9 +14,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @cssprop --jh-progress-indicator-color - The indicator color. Defaults to `--jh-color-content-brand-enabled`.
  * @customElement jh-progress
  */
-export class JhProgress extends LitElement {
-  /** @type {ElementInternals} */
-  #internals;
+export class JhProgress extends JhElement {
 
   /** @type {string} */
   #label;
@@ -202,7 +201,6 @@ export class JhProgress extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
     /** @type {Boolean} */
     this.indeterminate = false;
     /** @type {?string} */
@@ -214,17 +212,17 @@ export class JhProgress extends LitElement {
     /** @type {Boolean} */
     this.hideValue = false;
     /** @type {?string} */
-    this.#internals.ariaLabel;
+    this.internals.ariaLabel;
     /** @type {number} */
-    this.#internals.ariaValueMax;
+    this.internals.ariaValueMax;
     /** @type {number} */
-    this.#internals.ariaValueMin;
+    this.internals.ariaValueMin;
     /** @type {?number} */
-    this.#internals.ariaValueNow;
+    this.internals.ariaValueNow;
     /** @type {?string} */
-    this.#internals.ariaValueText;
+    this.internals.ariaValueText;
     /** @type {?string} */
-    this.#internals.role = 'progressbar';
+    this.internals.role = 'progressbar';
     /** @type {?string} */
     this.accessibleLabel = null;
     /** @type {?number} */
@@ -251,10 +249,10 @@ export class JhProgress extends LitElement {
 
   // Shared setter for elementInternals properties
   #setAttribute(ariaAttribute, newValue) {
-    const oldValue = this.#internals[ariaAttribute];
+    const oldValue = this.internals[ariaAttribute];
 
     if (newValue !== oldValue) {
-      this.#internals[ariaAttribute] = newValue;
+      this.internals[ariaAttribute] = newValue;
     }
     this.requestUpdate(ariaAttribute, oldValue);
   }
@@ -275,7 +273,7 @@ export class JhProgress extends LitElement {
   }
 
   get accessibleLabel() {
-    return this.#internals.ariaLabel;
+    return this.internals.ariaLabel;
   }
 
   set accessibleLabel(newValue) {
@@ -283,7 +281,7 @@ export class JhProgress extends LitElement {
   }
 
   get min() {
-    return this.#internals.ariaValueMin;
+    return this.internals.ariaValueMin;
   }
 
   set min(newValue) {
@@ -291,7 +289,7 @@ export class JhProgress extends LitElement {
   }
 
   get max() {
-    return this.#internals.ariaValueMax;
+    return this.internals.ariaValueMax;
   }
 
   set max(newValue) {
@@ -299,7 +297,7 @@ export class JhProgress extends LitElement {
   }
 
   get accessibleValueText() {
-    return this.#internals.ariaValueText;
+    return this.internals.ariaValueText;
   }
 
   set accessibleValueText(newValue) {
@@ -307,7 +305,7 @@ export class JhProgress extends LitElement {
   }
 
   get value() {
-    return this.#internals.ariaValueNow; 
+    return this.internals.ariaValueNow; 
   }
 
   set value(newValue) {
@@ -414,4 +412,4 @@ export class JhProgress extends LitElement {
   }
 }
 
-customElements.define('jh-progress', JhProgress);
+JhElement.register('jh-progress', JhProgress);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-progress` to extend off of `jh-element` component. Changes include:

- Component extends `jh-element`.
- Updates `#internals` property to `jh-element` `internals` property.
- Component definition replaced by `jh-element` `register` method.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

_add any other details on how to test_ 

## Notes/Dependencies

- `jh-element` PR should be merged first.


