### PR TITLE
[jh-radio] Update inheritance from LitElement to JhElementFeature/jh element radio

### DIFF
--- a/packages/jh-elements/components/radio/radio.js
+++ b/packages/jh-elements/components/radio/radio.js
@@ -59,7 +59,7 @@ import { JhElement } from '../element/element.js';
  * Defaults to `--jh-border-control-color`.
  * @cssprop --jh-radio-status-color-background-selected-disabled - The status mark color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the radio has changed. Event payload includes the `checked` state of the radio and can be accessed via `e.detail.state.checked`.
+ * @event jh-change - Dispatched when the state of the radio has changed.
  *
  * @customElement jh-radio */
 
@@ -370,11 +370,7 @@ export class JhRadio extends JhElement {
     if (this.checked) return;
 
     this.checked = true;
-    this.dispatchCustomEvent('jh-change', {
-      state: {
-        checked: this.checked,
-      },
-    });
+    this.dispatchCustomEvent('jh-change');
   }
 
   #handleKeydown(e) {

--- a/packages/jh-elements/components/radio/radio.js
+++ b/packages/jh-elements/components/radio/radio.js
@@ -2,9 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
-
-let id = 0;
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-radio-opacity-disabled - The radio opacity when disabled. Defaults to `--jh-opacity-disabled`.
@@ -60,16 +59,11 @@ let id = 0;
  * Defaults to `--jh-border-control-color`.
  * @cssprop --jh-radio-status-color-background-selected-disabled - The status mark color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the radio has changed.
+ * @event jh-change - Dispatched when the state of the radio has changed. Event payload includes the `checked` state of the radio and can be accessed via `e.detail.state.checked`.
  *
  * @customElement jh-radio */
 
-export class JhRadio extends LitElement {
-
-  /** @type {?Number} */
-  #id;
-  /** @type {ElementInternals} */
-  #internals;
+export class JhRadio extends JhElement {
 
   static get styles() {
     return css`
@@ -321,8 +315,7 @@ export class JhRadio extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'radio';
+    this.internals.role = 'radio';
     /** @type {?string} */
     this.accessibleLabel = null;
     /** @type {?boolean} */
@@ -342,14 +335,13 @@ export class JhRadio extends LitElement {
 
   connectedCallback() {
     super.connectedCallback();
-    this.#id = id++;
     this.setAttribute('tabindex', '0');
     this.setAttribute('aria-checked', `${this.checked}`);
     if (this.accessibleLabel) {
       this.setAttribute('aria-label', `${this.accessibleLabel}`);
     }
     if (this.helperText) {
-      this.setAttribute('aria-describedby', `radio-helper-text-${this.#id}`);
+      this.setAttribute('aria-describedby', `radio-helper-text-${this.uniqueId}`);
     }
 
     let observer = new MutationObserver(this.#updateArias.bind(this));
@@ -378,12 +370,11 @@ export class JhRadio extends LitElement {
     if (this.checked) return;
 
     this.checked = true;
-    const options = {
-      bubbles: true,
-      composed: true,
-      cancelable: true,
-    };
-    this.dispatchEvent(new CustomEvent('jh-change', options));
+    this.dispatchCustomEvent('jh-change', {
+      state: {
+        checked: this.checked,
+      },
+    });
   }
 
   #handleKeydown(e) {
@@ -398,7 +389,7 @@ export class JhRadio extends LitElement {
 
     if (this.helperText) {
       helperText = html`
-        <p class="helper-text" id="radio-helper-text-${this.#id}">
+        <p class="helper-text" id="radio-helper-text-${this.uniqueId}">
           ${this.helperText}
         </p>
       `;
@@ -419,4 +410,4 @@ export class JhRadio extends LitElement {
     `;
   }
 }
-customElements.define('jh-radio', JhRadio);
+JhRadio.register('jh-radio', JhRadio);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5613,12 +5613,16 @@
           "attribute": "value",
           "description": "Sets the value of the radio.",
           "type": "?string"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the radio has changed."
+          "description": "Dispatched when the state of the radio has changed. Event payload includes the `checked` state of the radio and can be accessed via `e.detail.state.checked`."
         }
       ],
       "cssProperties": [

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5622,7 +5622,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the radio has changed. Event payload includes the `checked` state of the radio and can be accessed via `e.detail.state.checked`."
+          "description": "Dispatched when the state of the radio has changed."
         }
       ],
       "cssProperties": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-radio` component to extend `JhElement` instead of `LitElement`. Changes include:
- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Replace private `#id` with `uniqueId` from base class
- Migrate `jh-change` event to use `dispatchCustomEvent`.
- Use `JhRadio.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies


