### PR TITLE
[jh-radio-group] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/radio-group/radio-group.js
+++ b/packages/jh-elements/components/radio-group/radio-group.js
@@ -2,10 +2,10 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
+import { JhElement } from '../element/element.js';
 
-let id = 0;
 /**
  *
  * @cssprop --jh-radio-group-label-color-text - The label text color. Defaults to `--jh-color-content-primary-enabled`.
@@ -21,19 +21,15 @@ let id = 0;
  *
  * @slot default - Use to insert `<jh-radio>` components(s).
  * 
- * @event jh-change - Dispatched when the value of the radio group has changed.
+ * @event jh-change - Dispatched when the value of the radio group has changed. Event payload includes the `value` and can be accessed via `e.detail.state.value`.
  *
  * @customElement jh-radio-group
  */
-export class JhRadioGroup extends LitElement {
+export class JhRadioGroup extends JhElement {
   static get formAssociated() {
     return true;
   }
   #checked;
-  /** @type {?Number} */
-  #id;
-  /** @type {ElementInternals} */
-  #internals;
   /** @type {?string} */
   #value;
 
@@ -208,7 +204,6 @@ export class JhRadioGroup extends LitElement {
   }
   constructor() {
     super();
-    this.#internals = this.attachInternals();
     /** @type {?string} */
     this.accessibleLabel = null;
     /** @type {boolean} */
@@ -237,11 +232,6 @@ export class JhRadioGroup extends LitElement {
     this.addEventListener('focusout', this.#handleFocusOut);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   firstUpdated() {
     this._syncDisabledToChildren();
   }
@@ -257,12 +247,12 @@ export class JhRadioGroup extends LitElement {
    * @type {?HTMLFormElement}
    */
   get form() {
-    return this.#internals.form;
+    return this.internals.form;
   }
 
   /** @ignore */
   get validity() {
-    return this.#internals.validity;
+    return this.internals.validity;
   }
 
   /** @type {?string} */
@@ -274,7 +264,7 @@ export class JhRadioGroup extends LitElement {
     const oldValue = this.#value;
     if (newValue !== oldValue) {
       this.#value = newValue;
-      this.#internals.setFormValue(newValue);
+      this.internals.setFormValue(newValue);
     }
     this.requestUpdate('value', oldValue);
   }
@@ -322,12 +312,11 @@ export class JhRadioGroup extends LitElement {
       this.#checked = e.target;
       this.#updateChecked();
 
-      const options = {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-      };
-      this.dispatchEvent(new CustomEvent('jh-change', options));
+      this.dispatchCustomEvent('jh-change', {
+        state: {
+          value: this.value,
+        },
+      });
     }
   }
 
@@ -390,11 +379,11 @@ export class JhRadioGroup extends LitElement {
 
   #getAriaDescribedBy() {
     if (this.errorText && this.invalid && this.helperText && this.label) {
-      return `radio-group-error-${this.#id} radio-group-helper-${this.#id}`;
+      return `radio-group-error-${this.uniqueId} radio-group-helper-${this.uniqueId}`;
     } else if (this.errorText && this.invalid) {
-      return `radio-group-error-${this.#id}`;
+      return `radio-group-error-${this.uniqueId}`;
     } else if (this.helperText && this.label) {
-      return `radio-group-helper-${this.#id}`;
+      return `radio-group-helper-${this.uniqueId}`;
     }
   }
 
@@ -415,28 +404,28 @@ export class JhRadioGroup extends LitElement {
     if (this.helperText) {
       helperText = html`<p
         class="helper-text"
-        id="radio-group-helper-${this.#id}"
+        id="radio-group-helper-${this.uniqueId}"
       >
         ${this.helperText}
       </p>`;
     }
 
     if (this.label) {
-      label = html`<legend class="label" for="radio-group-label-${this.#id}">
+      label = html`<legend class="label" for="radio-group-label-${this.uniqueId}">
           ${this.label}${indicator}
         </legend>
         ${helperText}`;
     }
 
     if (this.invalid && this.errorText) {
-      errorText = html`<p class="error-text" id="radio-group-error-${this.#id}">
+      errorText = html`<p class="error-text" id="radio-group-error-${this.uniqueId}">
         ${this.errorText}
       </p>`;
     }
     return html`
       <fieldset
         role="radiogroup"
-        id=${ifDefined(this.label ? `radio-group-label-${this.#id}` : null)}
+        id=${ifDefined(this.label ? `radio-group-label-${this.uniqueId}` : null)}
         aria-describedby=${ifDefined(this.#getAriaDescribedBy())}
         aria-disabled=${ifDefined(this.disabled ? 'true' : null)}
         aria-required=${ifDefined(this.required ? 'true' : 'false')}
@@ -452,4 +441,4 @@ export class JhRadioGroup extends LitElement {
     `;
   }
 }
-customElements.define('jh-radio-group', JhRadioGroup);
+JhRadioGroup.register('jh-radio-group', JhRadioGroup);

--- a/packages/jh-elements/components/radio-group/radio-group.js
+++ b/packages/jh-elements/components/radio-group/radio-group.js
@@ -312,11 +312,7 @@ export class JhRadioGroup extends JhElement {
       this.#checked = e.target;
       this.#updateChecked();
 
-      this.dispatchCustomEvent('jh-change', {
-        state: {
-          value: this.value,
-        },
-      });
+      this.dispatchCustomEvent('jh-change');
     }
   }
 

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5497,12 +5497,16 @@
           "attribute": "value",
           "description": "Sets the value of the radio group.",
           "type": "?string"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the value of the radio group has changed."
+          "description": "Dispatched when the value of the radio group has changed. Event payload includes the `value` and can be accessed via `e.detail.state.value`."
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-radio-group` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Replace private `#id` with inherited `uniqueId`
- Migrate `jh-change` event to `dispatchCustomEvent` with `state.value`
- Update `@event` JSDoc with new detail path
- Use `JhRadioGroup.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**


## Notes/Dependencies
- Jh-element PR needs to be merged first.


