### PR TITLE
[jh-input-search] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/input-search/input-search.js
+++ b/packages/jh-elements/components/input-search/input-search.js
@@ -41,4 +41,4 @@ export class JhInputSearch extends JhInput {
     `;
   }
 }
-customElements.define('jh-input-search', JhInputSearch);
+JhInputSearch.register('jh-input-search', JhInputSearch);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-input-search` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.





