### PR TITLE
[jh-select] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -454,11 +454,7 @@ export class JhSelect extends JhInput {
       this.#scrollToActiveItem();
 
       //dispatch a jh-change event when the selected value changes.
-      this.dispatchCustomEvent('jh-change', {
-        state: {
-          value: this.value,
-        },
-      });
+      this.dispatchCustomEvent('jh-change');
     }
   }
 

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -60,7 +60,7 @@ import { JhFilter } from './filtering.js';
  * @slot jh-select-trigger-open - Use to replace the default chevron icon displayed when the select menu is open.
  * @slot jh-select-trigger-closed - Use to replace the default chevron icon displayed when the select menu is closed.
  *
- * @event jh-change - Dispatched when the selected value changes.
+ * @event jh-change - Dispatched when the selected value changes. Event payload includes the `value` and can be accessed via `e.detail.state.value`.
  */
 export class JhSelect extends JhInput {
   /** @type {?string} */
@@ -454,12 +454,11 @@ export class JhSelect extends JhInput {
       this.#scrollToActiveItem();
 
       //dispatch a jh-change event when the selected value changes.
-      const options = {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-      };
-      this.dispatchEvent(new CustomEvent('jh-change', options));
+      this.dispatchCustomEvent('jh-change', {
+        state: {
+          value: this.value,
+        },
+      });
     }
   }
 
@@ -657,4 +656,4 @@ export class JhSelect extends JhInput {
   }
 }
 
-customElements.define('jh-select', JhSelect);
+JhSelect.register('jh-select', JhSelect);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6075,7 +6075,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the selected value changes."
+          "description": "Dispatched when the selected value changes. Event payload includes the `value` and can be accessed via `e.detail.state.value`."
         },
         {
           "name": "jh-select",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-select` component to use `JhElement` patterns. `JhSelect` extends `JhInput` which already extends `JhElement`. Changes include:

- Migrate `jh-change` event to `dispatchCustomEvent` with `state.value`
- Update `@event` JSDoc with new detail path
- Use `JhSelect.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

## Notes/Dependencies

- Jh-element PR needs to be merged first.


