### PR TITLE
[jh-switch] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/switch/switch.js
+++ b/packages/jh-elements/components/switch/switch.js
@@ -23,7 +23,7 @@ import { JhElement } from '../element/element.js';
  * @cssprop --jh-switch-track-color-background-selected-active - The track color when selected and active. Defaults to `--jh-color-content-brand-active`.
  * @cssprop --jh-switch-track-color-background-selected-disabled - The track color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the switch has changed. Event payload includes the `checked` state and can be accessed via `e.detail.state.checked`.
+ * @event jh-change - Dispatched when the state of the switch has changed.
  *
  * @customElement jh-switch
  */
@@ -253,11 +253,7 @@ export class JhSwitch extends JhElement {
   #handleClick() {
     if (!this.disabled && this.accessibleDisabled !== 'true') {
       this.checked = !this.checked;
-      this.dispatchCustomEvent('jh-change', {
-        state: {
-          checked: this.checked,
-        },
-      });
+      this.dispatchCustomEvent('jh-change');
     }
   }
 

--- a/packages/jh-elements/components/switch/switch.js
+++ b/packages/jh-elements/components/switch/switch.js
@@ -2,10 +2,9 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
-
-let id = 0;
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-switch-opacity-disabled - The switch opacity when disabled. Defaults to `--jh-opacity-disabled`.
@@ -24,13 +23,11 @@ let id = 0;
  * @cssprop --jh-switch-track-color-background-selected-active - The track color when selected and active. Defaults to `--jh-color-content-brand-active`.
  * @cssprop --jh-switch-track-color-background-selected-disabled - The track color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the switch has changed.
+ * @event jh-change - Dispatched when the state of the switch has changed. Event payload includes the `checked` state and can be accessed via `e.detail.state.checked`.
  *
  * @customElement jh-switch
  */
-export class JhSwitch extends LitElement {
-  /** @type {?Number} */
-  #id;
+export class JhSwitch extends JhElement {
 
   static get styles() {
     return css`
@@ -253,20 +250,14 @@ export class JhSwitch extends LitElement {
     this.label = null;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   #handleClick() {
     if (!this.disabled && this.accessibleDisabled !== 'true') {
       this.checked = !this.checked;
-      const options = {
-        bubbles: true,
-        composed: true,
-        cancelable: true,
-      };
-      this.dispatchEvent(new CustomEvent('jh-change', options));
+      this.dispatchCustomEvent('jh-change', {
+        state: {
+          checked: this.checked,
+        },
+      });
     }
   }
 
@@ -276,7 +267,7 @@ export class JhSwitch extends LitElement {
 
     if (this.helperText) {
       helperText = html`
-        <p class="helper-text" id="switch-helper-text-${this.#id}">
+        <p class="helper-text" id="switch-helper-text-${this.uniqueId}">
           ${this.helperText}
         </p>
       `;
@@ -285,7 +276,7 @@ export class JhSwitch extends LitElement {
     if (this.label) {
       label = html`
         <div class="label-container">
-          <label class="label-text" for="switch-label-${this.#id}">
+          <label class="label-text" for="switch-label-${this.uniqueId}">
             ${this.label}
           </label>
           ${helperText}
@@ -300,11 +291,11 @@ export class JhSwitch extends LitElement {
         aria-label="${ifDefined(this.accessibleLabel)}"
         aria-disabled="${ifDefined(this.accessibleDisabled)}"
         type="button"
-        aria-describedby=${this.helperText ? `switch-helper-text-${this.#id}` : null}
+        aria-describedby=${this.helperText ? `switch-helper-text-${this.uniqueId}` : null}
         ?checked=${this.checked}
         ?disabled=${this.disabled}
         aria-pressed="${this.checked}"
-        id="switch-label-${this.#id}"
+        id="switch-label-${this.uniqueId}"
       ></button>
       <span aria-hidden="true"></span>
       ${label}
@@ -312,4 +303,4 @@ export class JhSwitch extends LitElement {
   }
 }
 
-customElements.define('jh-switch', JhSwitch);
+JhSwitch.register('jh-switch', JhSwitch);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6470,12 +6470,16 @@
           "attribute": "label",
           "description": "Describes the intent of the switch.",
           "type": "?string"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the switch has changed."
+          "description": "Dispatched when the state of the switch has changed. Event payload includes the `checked` state and can be accessed via `e.detail.state.checked`."
         }
       ],
       "cssProperties": [

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6479,7 +6479,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the switch has changed. Event payload includes the `checked` state and can be accessed via `e.detail.state.checked`."
+          "description": "Dispatched when the state of the switch has changed."
         }
       ],
       "cssProperties": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-switch` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Replace private `#id` with inherited `uniqueId`
- Migrate `jh-change` event to `dispatchCustomEvent`
- Use `JhSwitch.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The jh-element PR needs to be merged first.


