### PR TITLE
[jh-tag] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/tag/tag.js
+++ b/packages/jh-elements/components/tag/tag.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '@jack-henry/jh-icons/icons-wc/icon-xmark.js';
 import '../button/button.js';
 import '../tooltip/tooltip.js';
@@ -42,7 +43,7 @@ import '../tooltip/tooltip.js';
  * @event jh-dismiss - Dispatched when the tag is dismissed.
  * @customElement jh-tag
  */
-export class JhTag extends LitElement {
+export class JhTag extends JhElement {
 
   static get styles() {
     return css`
@@ -357,13 +358,7 @@ export class JhTag extends LitElement {
 
   #handleDismissal(e) {
     e.stopPropagation();
-    this.dispatchEvent(
-      new CustomEvent('jh-dismiss', {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      })
-    );
+    this.dispatchCustomEvent('jh-dismiss');
 
     if (this.removeOnDismiss) {
       this.remove();
@@ -422,4 +417,4 @@ export class JhTag extends LitElement {
   }
 }
 
-customElements.define('jh-tag', JhTag);
+JhTag.register('jh-tag', JhTag);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -7334,6 +7334,10 @@
           "description": "Removes the tag after the dismiss button is activated.",
           "type": "?Boolean",
           "default": "false"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "events": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-tag` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited base class features
- Migrate `jh-dismiss` event to use `dispatchCustomEvent`
- Use `JhTag.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

Jh-element PR needs to be merged first.