### PR TITLE
[jh-tag-group] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/tag-group/tag-group.js
+++ b/packages/jh-elements/components/tag-group/tag-group.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * Tag Group
@@ -10,9 +11,7 @@ import { LitElement, css, html } from 'lit';
  * @slot default - Use to insert `<jh-tag>` component(s).
  * @customElement jh-tag-group
  */
-export class JhTagGroup extends LitElement {
-  /** @type {ElementInternals} */
-  #internals;
+export class JhTagGroup extends JhElement {
 
   static get styles() {
     return css`
@@ -43,8 +42,7 @@ export class JhTagGroup extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'group';
+    this.internals.role = 'group';
     /** @type {'start'| 'end'} */
     this.alignment = 'start';
   }
@@ -54,4 +52,4 @@ export class JhTagGroup extends LitElement {
   }
 }
 
-customElements.define('jh-tag-group', JhTagGroup);
+JhTagGroup.register('jh-tag-group', JhTagGroup);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-tag-group` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Use `JhTagGroup.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

JhElement PR needs to be merged first.