### PR TITLE
[jh-toast] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/toast/toast.js
+++ b/packages/jh-elements/components/toast/toast.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '../notification/notification.js';
 
 /**
@@ -15,7 +16,7 @@ import '../notification/notification.js';
  * @event jh-dismiss - Dispatched when the toast is dismissed.
  * @customElement jh-toast
  */
-export class JhToast extends LitElement {
+export class JhToast extends JhElement {
   static get styles() {
     return css`
       @keyframes fadeInUp  {
@@ -114,17 +115,7 @@ export class JhToast extends LitElement {
   }
 
   #removeToast() {
-    this.#dispatch('jh-dismiss');
-  }
-
-  #dispatch(name) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      })
-    );
+    this.dispatchCustomEvent('jh-dismiss');
   }
 
   #handleDismiss() {
@@ -165,4 +156,4 @@ export class JhToast extends LitElement {
   }
 }
 
-customElements.define('jh-toast', JhToast);
+JhToast.register('jh-toast', JhToast);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-toast` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited base class features
- Migrate `jh-dismiss` event dispatching to use `dispatchCustomEvent`
- Use `JhToast.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

JhElement PR needs to be merged first.