### PR TITLE
[jh-toast-controller] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/toast-controller/toast-controller.js
+++ b/packages/jh-elements/components/toast-controller/toast-controller.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '../toast/toast.js';
 
 /**
@@ -12,7 +13,7 @@ import '../toast/toast.js';
  * 
  * @customElement jh-toast-controller
  */
-export class JhToastController extends LitElement {
+export class JhToastController extends JhElement {
   static get styles() {
     return css`
       :host {
@@ -66,13 +67,7 @@ export class JhToastController extends LitElement {
 
   // controller dispatches jh-dismiss event and calls handleDismiss method
   #dispatch(name, toast) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      }) 
-    );
+    this.dispatchCustomEvent(name);
     this.#handleDismiss(toast);
   }
 
@@ -117,6 +112,6 @@ export class JhToastController extends LitElement {
     `;
   }
 }
-customElements.define('jh-toast-controller', JhToastController);
+JhToastController.register('jh-toast-controller', JhToastController);
 
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-toast-controller` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited base class features
- Migrate `jh-dismiss` event dispatching to use `dispatchCustomEvent`
- Use `JhToastController.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

JhElement PR needs to be merged first.

