### PR TITLE
[jh-table] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/table/table.js
+++ b/packages/jh-elements/components/table/table.js
@@ -2,13 +2,12 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import '../table-header-cell/table-header-cell.js';
 import '../table-data-cell/table-data-cell.js';
 import '../table-row/table-row.js';
-
-let id = 0;
 
 /**
  * Table
@@ -29,9 +28,7 @@ let id = 0;
  * @slot jh-table-toolbar - Use to insert toolbar.
  * @customElement jh-table
  */
-export class JhTable extends LitElement {
-  /** @type {?Number} */
-  #id;
+export class JhTable extends JhElement {
 
   static get styles() {
     return css`
@@ -289,11 +286,6 @@ export class JhTable extends LitElement {
     this.addEventListener('jh-sort', this.#handleSort);
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this.observer) {
@@ -349,12 +341,12 @@ export class JhTable extends LitElement {
 
   render() {
     return html`
-      <slot name="jh-table-caption" id="table-caption-${this.#id}" @slotchange=${this.#handleSlot}></slot>
+      <slot name="jh-table-caption" id="table-caption-${this.uniqueId}" @slotchange=${this.#handleSlot}></slot>
       <slot name="jh-table-toolbar" @slotchange=${this.#handleSlot}></slot>
       <div class="table-wrapper">
         <div class="table-container" tabindex="${ifDefined(this.scrollable ? '0' : null)}">
           <div class="table" role="table" 
-          aria-labelledby="table-caption-${this.#id}" aria-label=${ifDefined(this.accessibleLabel === '' ? null : this.accessibleLabel)}>
+          aria-labelledby="table-caption-${this.uniqueId}" aria-label=${ifDefined(this.accessibleLabel === '' ? null : this.accessibleLabel)}>
             <slot name="jh-table-header" class="header" role="rowgroup"></slot>
             <slot class="body" role="rowgroup"></slot>
             <slot name="jh-table-footer" class="footer" role="rowgroup"></slot>
@@ -366,4 +358,4 @@ export class JhTable extends LitElement {
   }
 }
 
-customElements.define('jh-table', JhTable);
+JhTable.register('jh-table', JhTable);

--- a/packages/jh-elements/components/toast-controller/toast-controller.js
+++ b/packages/jh-elements/components/toast-controller/toast-controller.js
@@ -2,8 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { css, html } from 'lit';
-import { JhElement } from '../element/element.js';
+import { LitElement, css, html } from 'lit';
 import '../toast/toast.js';
 
 /**
@@ -13,7 +12,7 @@ import '../toast/toast.js';
  * 
  * @customElement jh-toast-controller
  */
-export class JhToastController extends JhElement {
+export class JhToastController extends LitElement {
   static get styles() {
     return css`
       :host {
@@ -67,7 +66,13 @@ export class JhToastController extends JhElement {
 
   // controller dispatches jh-dismiss event and calls handleDismiss method
   #dispatch(name, toast) {
-    this.dispatchCustomEvent(name);
+    this.dispatchEvent(
+      new CustomEvent(name, {
+        bubbles: true,
+        cancelable: true,
+        composed: true,
+      }) 
+    );
     this.#handleDismiss(toast);
   }
 
@@ -112,6 +117,6 @@ export class JhToastController extends JhElement {
     `;
   }
 }
-JhToastController.register('jh-toast-controller', JhToastController);
+customElements.define('jh-toast-controller', JhToastController);
 
 

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1272,17 +1272,6 @@
       ]
     },
     {
-      "name": "jh-element",
-      "path": "./components/element/element.js",
-      "description": "Element",
-      "properties": [
-        {
-          "name": "uniqueId",
-          "type": "number"
-        }
-      ]
-    },
-    {
       "name": "jh-icon",
       "path": "./components/icon/icon.js",
       "attributes": [
@@ -7143,6 +7132,10 @@
           "description": "Makes the table horizontally scrollable on smaller screens.",
           "type": "Boolean",
           "default": "false"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-table` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Replace private `#id` field and module-level counter with inherited `uniqueId`
- Use `JhTable.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The jh-element PR needs to be merged first.