### PR TITLE
[jh-table-data-cell] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/table-data-cell/table-data-cell.js
+++ b/packages/jh-elements/components/table-data-cell/table-data-cell.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * Table Cell
@@ -30,10 +31,7 @@ import { LitElement, css, html } from 'lit';
  * 
  * @customElement jh-table-cell
  */
-export class JhTableDataCell extends LitElement {
-
-  /** @type {ElementInternals} */
-  #internals;
+export class JhTableDataCell extends JhElement {
 
   static get styles() {
     return css`
@@ -89,8 +87,7 @@ export class JhTableDataCell extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'cell';
+    this.internals.role = 'cell';
     /** 
      * Sets the horizontal alignment of the content.
      * @attr horizontal-align
@@ -105,4 +102,4 @@ export class JhTableDataCell extends LitElement {
   }
 }
 
-customElements.define('jh-table-data-cell', JhTableDataCell);
+JhTableDataCell.register('jh-table-data-cell', JhTableDataCell);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-table-data-cell` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Use `JhTableDataCell.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The jh-element PR needs to be merged first.