### PR TITLE
[jh-table-header-cell] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/table-header-cell/table-header-cell.js
+++ b/packages/jh-elements/components/table-header-cell/table-header-cell.js
@@ -2,12 +2,11 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '@jack-henry/jh-icons/icons-wc/icon-arrow-up-arrow-down.js';
 import '@jack-henry/jh-icons/icons-wc/icon-arrow-up-small.js';
 import '@jack-henry/jh-icons/icons-wc/icon-arrow-down-small.js';
-
-let id = 0;
 
 /**
  * Table Header Cell
@@ -66,13 +65,10 @@ let id = 0;
  * @slot jh-table-sorted-none - Use to insert a custom icon for no sort.
  * @slot default - Use to insert table header text.
  * 
- * @event jh-sort - Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.column`, `e.detail.sorted`, and ` e.detail.id`.  
+ * @event jh-sort - Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.state.sorted`, and `e.detail.reference.id`.  
  * @customElement jh-table-header-cell
  */
-export class JhTableHeaderCell extends LitElement {
-
-  /** @type {ElementInternals} */
-  #internals;
+export class JhTableHeaderCell extends JhElement {
 
   static get styles() {
     return css`
@@ -208,8 +204,7 @@ export class JhTableHeaderCell extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'columnheader';
+    this.internals.role = 'columnheader';
     /** 
      * Sets the horizontal alignment of the content.
      * @attr horizontal-align
@@ -233,7 +228,7 @@ export class JhTableHeaderCell extends LitElement {
   connectedCallback() {
     super.connectedCallback();
     /** @ignore */
-    this.id = `table-header-${id++}`;
+    this.id = `table-header-${this.uniqueId}`;
     if (this.sortable) {
     this.setAttribute('tabindex', '0');
     this.setAttribute('aria-sort', this.sorted);
@@ -261,18 +256,15 @@ export class JhTableHeaderCell extends LitElement {
     
     this.setAttribute('aria-sort', this.sorted);
 
-    this.dispatchEvent(
-      new CustomEvent('jh-sort', {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-        detail: {
-          column: this,
-          sorted: this.sorted,
-          id: this.id,
-        },
-      })
-    );
+    this.dispatchCustomEvent('jh-sort', {
+      state: {
+        sorted: this.sorted,
+      },
+      reference: {
+        column: this,
+        id: this.id,
+      },
+    });
   }
 
   #getSortingIcon() {
@@ -318,4 +310,4 @@ export class JhTableHeaderCell extends LitElement {
     }
 }
 
-customElements.define('jh-table-header-cell', JhTableHeaderCell);
+JhTableHeaderCell.register('jh-table-header-cell', JhTableHeaderCell);

--- a/packages/jh-elements/components/table-header-cell/table-header-cell.js
+++ b/packages/jh-elements/components/table-header-cell/table-header-cell.js
@@ -65,7 +65,7 @@ import '@jack-henry/jh-icons/icons-wc/icon-arrow-down-small.js';
  * @slot jh-table-sorted-none - Use to insert a custom icon for no sort.
  * @slot default - Use to insert table header text.
  * 
- * @event jh-sort - Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.state.sorted`, and `e.detail.reference.id`.  
+ * @event jh-sort - Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.reference.sorted`, and `e.detail.reference.id`.  
  * @customElement jh-table-header-cell
  */
 export class JhTableHeaderCell extends JhElement {
@@ -257,10 +257,8 @@ export class JhTableHeaderCell extends JhElement {
     this.setAttribute('aria-sort', this.sorted);
 
     this.dispatchCustomEvent('jh-sort', {
-      state: {
-        sorted: this.sorted,
-      },
       reference: {
+        sorted: this.sorted,
         column: this,
         id: this.id,
       },

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6790,12 +6790,16 @@
           "description": "Sets the order in which the items in the column are sorted.",
           "type": "'none' | 'ascending' | 'descending'",
           "default": "\"none\""
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "events": [
         {
           "name": "jh-sort",
-          "description": "Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.column`, `e.detail.sorted`, and ` e.detail.id`."
+          "description": "Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.state.sorted`, and `e.detail.reference.id`."
         }
       ],
       "slots": [

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6799,7 +6799,7 @@
       "events": [
         {
           "name": "jh-sort",
-          "description": "Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.state.sorted`, and `e.detail.reference.id`."
+          "description": "Dispatched when a sortable header cell is activated. Event payload includes the column, sorted state, and id of the header cell and can be accessed via `e.detail.reference.column`, `e.detail.reference.sorted`, and `e.detail.reference.id`."
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-table-header-cell` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Replace module-level `id` counter with inherited `uniqueId`
- Migrate `jh-sort` event to use `dispatchCustomEvent` with `reference` groups
- Update `@event` JSDoc to document new detail access paths
- Use `JhTableHeaderCell.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

the jh-element PR needs to be merged first.