### PR TITLE
[jh-table-row] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/table-row/table-row.js
+++ b/packages/jh-elements/components/table-row/table-row.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * Table Row
@@ -17,10 +18,7 @@ import { LitElement, css, html } from 'lit';
  * @slot default - Use to insert `<jh-table-data-cell>`s or `<jh-table-header-cell>`s.
  * @customElement jh-table-row
  */
-export class JhTableRow extends LitElement {
-
-  /** @type {ElementInternals} */
-  #internals;
+export class JhTableRow extends JhElement {
 
   static get styles() {
     return css`
@@ -40,8 +38,7 @@ export class JhTableRow extends LitElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'row';
+    this.internals.role = 'row';
   }
 
   render() {
@@ -49,4 +46,4 @@ export class JhTableRow extends LitElement {
   }
 }
 
-customElements.define('jh-table-row', JhTableRow);
+JhTableRow.register('jh-table-row', JhTableRow);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-table-row` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Use `JhTableRow.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The jh-element PR needs to be merged first.