### PR TITLE
[jh-input-telephone] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/input-telephone/input-telephone.js
+++ b/packages/jh-elements/components/input-telephone/input-telephone.js
@@ -15,4 +15,4 @@ export class JhInputTelephone extends JhInput {
     inputEl.setAttribute('type', 'tel');
   }
 }
-customElements.define('jh-input-telephone', JhInputTelephone);
+JhInputTelephone.register('jh-input-telephone', JhInputTelephone);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-input-telephone` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.





