### PR TITLE
[jh-input-textarea] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -9,8 +9,8 @@ import { JhInput } from '../input/input.js';
 /**
  * @cssprop --jh-input-textarea-field-dimension-min-height - The input field minimum height. Defaults to `--jh-dimension-2000` when `size='small'`, `--jh-dimension-2200` when `size='medium'`, and `--jh-dimension-2400` when `size='large'`.
  *
- * @event jh-change - Dispatched when the value of the input has changed and input loses focus. Event payload includes the value of the input and can be accessed via `e.detail.value`.
- * @event jh-input - Dispatched when the value of the input has changed. Event payload includes the value of the input and can be accessed via `e.detail.value`. 
+ * @event jh-change - Dispatched when the value of the input has changed and input loses focus. Event payload includes the value of the input and can be accessed via `e.detail.state.value`.
+ * @event jh-input - Dispatched when the value of the input has changed. Event payload includes the value of the input and can be accessed via `e.detail.state.value`. 
  * @customElement jh-input-textarea
  */
 export class JhInputTextarea extends JhInput {

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -6,8 +6,6 @@ import { css, html } from 'lit';
 import { ifDefined } from 'lit/directives/if-defined.js';
 import { JhInput } from '../input/input.js';
 
-let id = 0;
-
 /**
  * @cssprop --jh-input-textarea-field-dimension-min-height - The input field minimum height. Defaults to `--jh-dimension-2000` when `size='small'`, `--jh-dimension-2200` when `size='medium'`, and `--jh-dimension-2400` when `size='large'`.
  *
@@ -16,8 +14,6 @@ let id = 0;
  * @customElement jh-input-textarea
  */
 export class JhInputTextarea extends JhInput {
-  /** @type {?number} */
-  #id;
   /** @type {?ResizeObserver} */
   #resizeObserver;
 
@@ -195,11 +191,6 @@ export class JhInputTextarea extends JhInput {
     this.wrap = null;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   disconnectedCallback() {
     super.disconnectedCallback();
     if (this.#resizeObserver) {
@@ -244,7 +235,7 @@ export class JhInputTextarea extends JhInput {
   renderInput() {
     return html`
       <textarea
-        id="jh-input-${this.#id}"
+        id="jh-input-${this.uniqueId}"
         aria-describedby=${this._getDescribedby()}
         aria-invalid=${ifDefined(this.invalid ? 'true' : null)}
         aria-label=${ifDefined(this.accessibleLabel === '' ? null : this.accessibleLabel)}

--- a/packages/jh-elements/components/input-textarea/input-textarea.js
+++ b/packages/jh-elements/components/input-textarea/input-textarea.js
@@ -268,4 +268,4 @@ export class JhInputTextarea extends JhInput {
     `
   }
 }
-customElements.define('jh-input-textarea', JhInputTextarea);
+JhInputTextarea.register('jh-input-textarea', JhInputTextarea);

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -3572,11 +3572,11 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the value of the input has changed and input loses focus. Event payload includes the value of the input and can be accessed via `e.detail.value`."
+          "description": "Dispatched when the value of the input has changed and input loses focus. Event payload includes the value of the input and can be accessed via `e.detail.state.value`."
         },
         {
           "name": "jh-input",
-          "description": "Dispatched when the value of the input has changed. Event payload includes the value of the input and can be accessed via `e.detail.value`."
+          "description": "Dispatched when the value of the input has changed. Event payload includes the value of the input and can be accessed via `e.detail.state.value`."
         },
         {
           "name": "jh-select",

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1272,17 +1272,6 @@
       ]
     },
     {
-      "name": "jh-element",
-      "path": "./components/element/element.js",
-      "description": "Element",
-      "properties": [
-        {
-          "name": "uniqueId",
-          "type": "number"
-        }
-      ]
-    },
-    {
       "name": "jh-icon",
       "path": "./components/icon/icon.js",
       "attributes": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-input-textarea` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.
2. Replace private `#id` with inherited `uniqueId`.
3. Updated `value` event payload property path to `e.detail.state.value`. 

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.





