### PR TITLE
[jh-input-url] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/input-url/input-url.js
+++ b/packages/jh-elements/components/input-url/input-url.js
@@ -28,4 +28,4 @@ export class JhInputUrl extends JhInput {
     inputEl.setAttribute('type', 'url');
   }
 }
-customElements.define('jh-input-url', JhInputUrl);
+JhInputUrl.register('jh-input-url', JhInputUrl);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-input-url` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.

