### PR TITLE
[jh-list-group] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/list-group/list-group.js
+++ b/packages/jh-elements/components/list-group/list-group.js
@@ -21,9 +21,6 @@ let id = 0;
  * @customElement jh-list-group
  */
 export class JhListGroup extends JhElement {
-  /** @type {?Number} */
-  #id;
-
   static get styles() {
     return css`
       :host {
@@ -77,22 +74,17 @@ export class JhListGroup extends JhElement {
     this.accessibleLabel = null;
   }
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.#id = id++;
-  }
-
   render() {
     return html`
       ${this.label
-        ? html`<div class="subheader" id="list-group-labelledby-${this.#id}">
+        ? html`<div class="subheader" id="list-group-labelledby-${this.uniqueId}">
             ${this.label}
           </div>`
         : null}
       <div
         role="group"
         aria-labelledby=${ifDefined(
-          this.label ? `list-group-labelledby-${this.#id}` : null
+          this.label ? `list-group-labelledby-${this.uniqueId}` : null
         )}
         aria-label=${ifDefined(this.accessibleLabel)}
       >

--- a/packages/jh-elements/components/list-group/list-group.js
+++ b/packages/jh-elements/components/list-group/list-group.js
@@ -101,4 +101,4 @@ export class JhListGroup extends JhElement {
     `;
   }
 }
-customElements.define('jh-list-group', JhListGroup);
+JhListGroup.register('jh-list-group', JhListGroup);

--- a/packages/jh-elements/components/list-group/list-group.js
+++ b/packages/jh-elements/components/list-group/list-group.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
 let id = 0;
@@ -19,7 +20,7 @@ let id = 0;
  * @slot default - Use to insert `<jh-list-item>` component(s).
  * @customElement jh-list-group
  */
-export class JhListGroup extends LitElement {
+export class JhListGroup extends JhElement {
   /** @type {?Number} */
   #id;
 

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1272,17 +1272,6 @@
       ]
     },
     {
-      "name": "jh-element",
-      "path": "./components/element/element.js",
-      "description": "Element",
-      "properties": [
-        {
-          "name": "uniqueId",
-          "type": "number"
-        }
-      ]
-    },
-    {
       "name": "jh-icon",
       "path": "./components/icon/icon.js",
       "attributes": [
@@ -4680,6 +4669,10 @@
           "attribute": "accessible-label",
           "description": "Sets an `aria-label` to assist screen reader users when no visible label is present.",
           "type": "?string"
+        },
+        {
+          "name": "uniqueId",
+          "type": "number"
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates `jh-list-group` to extend off of `jh-element` component. Changes include:

1. Component definition replaced by `jh-element` register method.
2. Replace private `#id` with inherited `uniqueId`.

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

- `jh-element` PR should be merged first.
