### PR TITLE
[jh-list-item] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/list-item/list-item.js
+++ b/packages/jh-elements/components/list-item/list-item.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '../divider/divider.js';
 import { ifDefined } from 'lit/directives/if-defined.js';
 
@@ -40,7 +41,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @slot jh-list-item-metadata - Use to insert custom metadata into the list-item.
  * @customElement jh-list-item
  */
-export class JhListItem extends LitElement {
+export class JhListItem extends JhElement {
   /** @type {ElementInternals} */
   #internals;
 

--- a/packages/jh-elements/components/list-item/list-item.js
+++ b/packages/jh-elements/components/list-item/list-item.js
@@ -42,9 +42,6 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @customElement jh-list-item
  */
 export class JhListItem extends JhElement {
-  /** @type {ElementInternals} */
-  #internals;
-
   static get styles() {
     return css`
       :host {
@@ -291,8 +288,7 @@ export class JhListItem extends JhElement {
 
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'listitem';
+    this.internals.role = 'listitem';
     /** @type {?boolean} */
     this.disabled = false;
     /** @type {null|0|8|16|24|32|40|48|56|64|72|80|88|96} */

--- a/packages/jh-elements/components/list-item/list-item.js
+++ b/packages/jh-elements/components/list-item/list-item.js
@@ -350,5 +350,4 @@ export class JhListItem extends JhElement {
     `;
   }
 }
-
-customElements.define('jh-list-item', JhListItem);
+JhListItem.register('jh-list-item', JhListItem);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->
## What It Does

Updates the `jh-list-item` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Use JhListItem.register() instead of customElements.define()

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The `jh-element` PR needs to be merged first.