### PR TITLE
[jh-menu] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/menu/menu.js
+++ b/packages/jh-elements/components/menu/menu.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-menu-z-index - The menu z-index. Defaults to `--jh-z-index-positive-1000`.
@@ -15,7 +16,7 @@ import { LitElement, css, html } from 'lit';
  * @slot default - Use to insert menu items.
  * @customElement jh-menu
  */
-export class JhMenu extends LitElement {
+export class JhMenu extends JhElement {
   /** @type {ElementInternals} */
   #internals;
 

--- a/packages/jh-elements/components/menu/menu.js
+++ b/packages/jh-elements/components/menu/menu.js
@@ -69,4 +69,4 @@ export class JhMenu extends JhElement {
     `;
   }
 }
-customElements.define('jh-menu', JhMenu);
+JhMenu.register('jh-menu', JhMenu);

--- a/packages/jh-elements/components/menu/menu.js
+++ b/packages/jh-elements/components/menu/menu.js
@@ -17,9 +17,6 @@ import { JhElement } from '../element/element.js';
  * @customElement jh-menu
  */
 export class JhMenu extends JhElement {
-  /** @type {ElementInternals} */
-  #internals;
-
   static get styles() {
     return css`
       :host {
@@ -58,8 +55,7 @@ export class JhMenu extends JhElement {
   }
   constructor() {
     super();
-    this.#internals = this.attachInternals();
-    this.#internals.role = 'menu';
+    this.internals.role = 'menu';
   }
   render() {
     return html`


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->
## What It Does

Updates the `jh-menu` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Extend `JhElement` and use inherited `internals` getter
- Remove private `#internals` field and `attachInternals()` call
- Use JhMenu.register() instead of customElements.define()

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The `jh-element` PR needs to be merged first.