### PR TITLE
[jh-notification] Update inheritance from LitElement to JhElement

### DIFF
--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -254,23 +254,13 @@ export class JhNotification extends JhElement {
   }
 
   #handleDismissal() {
-    this.#dispatch('jh-dismiss');
+    this.dispatchCustomEvent('jh-dismiss');
     // if notification is wrapped by jh-toast component, do not remove notification from DOM
     if (this.parentNode.host?.nodeName === 'JH-TOAST') {
       return;
     } else {
       this.remove();
     }   
-  }
-
-  #dispatch(name) {
-    this.dispatchEvent(
-      new CustomEvent(name, {
-        bubbles: true,
-        cancelable: true,
-        composed: true,
-      })
-    );
   }
 
   #getActionButtons() {

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -2,7 +2,8 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-import { LitElement, css, html } from 'lit';
+import { css, html } from 'lit';
+import { JhElement } from '../element/element.js';
 import '../button/button.js';
 import '@jack-henry/jh-icons/icons-wc/icon-xmark.js';
 
@@ -59,7 +60,7 @@ import '@jack-henry/jh-icons/icons-wc/icon-xmark.js';
  *
  * @customElement jh-notification
  */
-export class JhNotification extends LitElement {
+export class JhNotification extends JhElement {
   static get styles() {
     return css`
     :host {

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -332,5 +332,4 @@ export class JhNotification extends JhElement {
     `;
   }
 }
-
-customElements.define('jh-notification', JhNotification);
+JhNotification.register('jh-notification', JhNotification);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the `jh-notification` component to extend `JhElement` instead of `LitElement`. Changes include:

- Import `JhElement` instead of `LitElement`
- Migrate `jh-dismiss` event to use `dispatchCustomEvent` method
- Use `JhNotification.register()` instead of `customElements.define()`

**Idea number or other reference :** 33

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies

The jh-element PR needs to be merged first.