### PR TITLE
[V2] In Github Actions update actions to v6 and node to 24

### DIFF
--- a/.github/workflows/actions/install-dependencies/action.yaml
+++ b/.github/workflows/actions/install-dependencies/action.yaml
@@ -9,14 +9,14 @@ runs:
   using: "composite"
   steps:
     - name: Install PNPM
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
       with:
         version: 9.15.9
 
     - name: Install Nodejs
       uses: actions/setup-node@v6
       with:
-        node-version: 22
+        node-version: 24
         registry-url: 'https://registry.npmjs.org'
         cache: 'pnpm'
 

--- a/.github/workflows/chromatic-dev.yaml
+++ b/.github/workflows/chromatic-dev.yaml
@@ -14,7 +14,7 @@ jobs:
     name: Chromatic Deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -22,7 +22,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/jh-elements

--- a/.github/workflows/chromatic-next.yaml
+++ b/.github/workflows/chromatic-next.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Chromatic Deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/jh-elements

--- a/.github/workflows/chromatic-prod.yaml
+++ b/.github/workflows/chromatic-prod.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Chromatic Deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/jh-elements

--- a/.github/workflows/chromatic-release.yaml
+++ b/.github/workflows/chromatic-release.yaml
@@ -15,7 +15,7 @@ jobs:
     name: Chromatic Deployment
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -23,7 +23,7 @@ jobs:
         uses: ./.github/workflows/actions/install-dependencies
 
       - name: Publish to Chromatic
-        uses: chromaui/action@v1
+        uses: chromaui/action@latest
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
           workingDir: packages/jh-elements

--- a/.github/workflows/manual-publish.yaml
+++ b/.github/workflows/manual-publish.yaml
@@ -29,7 +29,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -11,7 +11,7 @@ jobs:
   reuse-linter:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: REUSE lint


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It updates the Github Actions to use Node 24 and compatible actions (`actions/checkout@v6`, `chromaui/action@latest`, `pnpm/action-setup@v6`).

**Idea number or other reference :** 302

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [X] Other (add details below)

**Additional Details**

Check that Github Actions are running correctly.

## Notes/Dependencies