### PR TITLE
[Next - Migration Docs] Adds upcoming release info to docs

### DIFF
--- a/packages/jh-ui/docs/whats-new/jh-elements.mdx
+++ b/packages/jh-ui/docs/whats-new/jh-elements.mdx
@@ -107,7 +107,7 @@ The width of `jh-switch` has been updated to 48px from 56px(as present in V1). A
 The `appearance` property has been deprecated. The component now uses a single, neutral default color for all instances.
 
 ### jh-tooltip
-The `jh-tooltip` component now utilizes a content slot instead of the deprecated `label` property to provide greater layout flexibility. The typography tokens have changed from `--jh-font-helper-regular-...` to `--jh-font-helper-bold-...`.
+The `jh-tooltip` component now utilizes a content slot instead of the deprecated `label` property to provide greater layout flexibility. Additionally, authors can now control the component's maximum width using the new --jh-tooltip-size-max-width styling hook. The typography tokens have also changed from `--jh-font-helper-regular-...` to `--jh-font-helper-bold-...`.
 
 ## New Components
 

--- a/packages/jh-ui/docs/whats-new/v2-release.mdx
+++ b/packages/jh-ui/docs/whats-new/v2-release.mdx
@@ -87,9 +87,9 @@ Provides a collection of common datasets and utilities for use with design syste
 
 We're introducing our validation library mixin that authors can use to add validation to their non design system components. This mixin is utilized by our form components, providing validation support. 
 
-### jh-element component (coming soon)
+### `JhElement` Base Class
 
-A common base that all components extend off of. This enables us to promote code reuse, share dependencies one time, etc. All components now officially extend off this component.
+All components now officially extend from `JhElement`. This new underlying base class drives better code reuse and allows dependencies to be shared efficiently across the library. Please note that JhElement serves strictly as a foundational class and is **not** intended to be implemented as a standalone component.
 
 ### Lit 3.0 Upgraded
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the migration docs:

- Adds `JhElement` class.
- Adds `jh-tooltip` `--jh-tooltip-size-max-width` styling hook. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a


