### PR TITLE
 Fix Storybook 10 Meta import path in hygen mdx template

### DIFF
--- a/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
+++ b/packages/jh-elements/_templates/component/new/element.mdx.ejs.t
@@ -10,7 +10,7 @@ SPDX-FileCopyrightText: 2025 Jack Henry
 
 SPDX-License-Identifier: Apache-2.0
  */}
-import { Meta, ArgTypes } from '@storybook/blocks';
+import { Meta, ArgTypes } from '@storybook/addon-docs/blocks';
 import * as stories from './<%= unprefixedName %>.stories.js';
 
 <Meta title="Components/<%= titleName %>" of={stories} />


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Updates the Meta import path in the `.mdx.ejs` file to align with the Storybook 10 upgrade.

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [x] Review `element.mdx.ejs` file

**Additional Details**

n/a

## Notes/Dependencies

n/a


