### PR TITLE
[Select] Add support for programmatic value setting

### DIFF
--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -247,7 +247,7 @@ export class JhSelect extends JhInput {
       this.#activeIndex = null;
 
       // If no value is set yet, use the selected flag as the initial default
-      if (!this.value) {
+      if (this.value == null) {
         const selectedOption = this.#flatOptions.find((opt) => opt.selected);
         if (selectedOption) {
           this.value = String(selectedOption.value);
@@ -266,7 +266,7 @@ export class JhSelect extends JhInput {
   }
 
   #syncDisplayValue() {
-    if (!this.value) {
+    if (this.value == null) {
       this.#displayValue = null;
       return;
     }

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -243,17 +243,39 @@ export class JhSelect extends JhInput {
           ...item,
         };
       });
-      // These will be the same until we add search functionality, at which point #flatOptions will be the filtered list and #allOptions will remain the source of truth.
       this.#flatOptions = this.#allOptions;
       this.#activeIndex = null;
 
-      // Set initial value from the selected flag in the data array
-      const selectedOption = this.#flatOptions.find((opt) => opt.selected);
-      if (selectedOption) {
-        this.value = String(selectedOption.value);
-        this.#displayValue = selectedOption.label;
+      // If no value is set yet, use the selected flag as the initial default
+      if (!this.value) {
+        const selectedOption = this.#flatOptions.find((opt) => opt.selected);
+        if (selectedOption) {
+          this.value = String(selectedOption.value);
+          this.#displayValue = selectedOption.label;
+        }
+      } else {
+        // Value already set — resolve display label from new options
+        this.#syncDisplayValue();
       }
     }
+
+    // Handle external value changes (e.g. .value = 'x' or value="x" attribute)
+    if (changedProperties.has('value') && !changedProperties.has('options')) {
+      this.#syncDisplayValue();
+    }
+  }
+
+  #syncDisplayValue() {
+    if (!this.value) {
+      this.#displayValue = null;
+      return;
+    }
+    const match = this.#flatOptions.find(
+      (opt) => String(opt.value) === String(this.value)
+    );
+    this.#displayValue = match
+      ? (match.label != null ? match.label : String(match.value))
+      : null;
   }
 
   #getIndexFromId(elementId) {
@@ -391,7 +413,9 @@ export class JhSelect extends JhInput {
       } else if (this.#activeIndex !== null) {
           this.#handleSelection(this.#activeIndex);
           this.#handleCloseSelect();
-        }
+      } else {
+        this.#handleCloseSelect();
+      }
         return;
 
       case 'Escape':

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -273,9 +273,7 @@ export class JhSelect extends JhInput {
     const match = this.#flatOptions.find(
       (opt) => String(opt.value) === String(this.value)
     );
-    this.#displayValue = match
-      ? (match.label != null ? match.label : String(match.value))
-      : null;
+    this.#displayValue = match ? (match.label ?? String(match.value)) : null;
   }
 
   #getIndexFromId(elementId) {

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -249,9 +249,12 @@ export class JhSelect extends JhInput {
 
       // Set initial value from the selected flag in the data array
       const selectedOption = this.#flatOptions.find((opt) => opt.selected);
-      if (selectedOption && !this.value) {
+      if (selectedOption) {
         this.value = String(selectedOption.value);
         this.#displayValue = selectedOption.label;
+      } else {
+       this.value = '';
+       this.#displayValue = null;
       }
     }
   }
@@ -299,7 +302,7 @@ export class JhSelect extends JhInput {
     }
   }
 
-  #handleOpenSelect() {
+  #handleOpenSelect({ keyboard = false } = {}) {
     if (this.disabled || this.readonly || !this.#flatOptions.length) return;
     if (!this.#inputWrapper || !this.#menuContainer) return;
 
@@ -310,8 +313,8 @@ export class JhSelect extends JhInput {
     requestAnimationFrame(() => {
       document.addEventListener('scroll', this.#boundDocumentScroll, true);
     });
-    // Set initial active to selected item or first item
-    if (this.#activeIndex === null) {
+    // Only set active item on keyboard open to avoid showing focus ring on mouse open
+    if (keyboard && this.#activeIndex === null) {
       const selectedIdx = this.#flatOptions.findIndex(
         (opt) => String(opt.value) === String(this.value));
       this.#setActiveItem(selectedIdx !== -1 ? selectedIdx : 0);
@@ -360,22 +363,26 @@ export class JhSelect extends JhInput {
     if (e.ctrlKey || e.metaKey) return;
 
     switch (e.key) {
-      case 'ArrowDown':
-        e.preventDefault();
-        if (!this.#open) {
-          this.#handleOpenSelect();
-        } else {
-          this.#setActiveItem(this.#activeIndex === null ? 0 : this.#activeIndex + 1);
-        }
-        return;
+    case 'ArrowDown':
+      e.preventDefault();
+      if (!this.#open) {
+        this.#handleOpenSelect({ keyboard: true });
+      } else {
+        const selectedIdx = this.#flatOptions.findIndex(
+          (opt) => String(opt.value) === String(this.value));
+        this.#setActiveItem((this.#activeIndex ?? selectedIdx) + 1);
+      }
+      return;
 
       case 'ArrowUp':
         e.preventDefault();
         if (!this.#open) {
-          this.#handleOpenSelect();
+          this.#handleOpenSelect({ keyboard: true });
         } else {
+          const selectedIdx = this.#flatOptions.findIndex(
+            (opt) => String(opt.value) === String(this.value));
           this.#setActiveItem(
-            this.#activeIndex === null ? this.#flatOptions.length - 1 : this.#activeIndex - 1);
+            (this.#activeIndex ?? (selectedIdx !== -1 ? selectedIdx : this.#flatOptions.length)) - 1);
         }
         return;
 
@@ -383,8 +390,8 @@ export class JhSelect extends JhInput {
       case ' ':
         e.preventDefault();
         if (!this.#open) {
-          this.#handleOpenSelect();
-        } else if (this.#activeIndex !== null) {
+          this.#handleOpenSelect({ keyboard: true }); 
+      } else if (this.#activeIndex !== null) {
           this.#handleSelection(this.#activeIndex);
           this.#handleCloseSelect();
         }

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -252,9 +252,6 @@ export class JhSelect extends JhInput {
       if (selectedOption) {
         this.value = String(selectedOption.value);
         this.#displayValue = selectedOption.label;
-      } else {
-       this.value = '';
-       this.#displayValue = null;
       }
     }
   }

--- a/packages/jh-elements/components/select/select.mdx
+++ b/packages/jh-elements/components/select/select.mdx
@@ -31,9 +31,9 @@ To use `<jh-select>`, set the necessary attributes and pass your options using t
 const myOptions = [
   { label: "Basic Checking", value: "checking-01" },
   { label: "High-Yield Savings", value: "savings-01", disabled: true },
-  { label: "Money Market", value: "money-market-01", selected: true },
+  { label: "Money Market", value: "money-market-01" },
 ];
-<jh-select label="Account type" helper-text="Choose an account" .options=${myOptions}></jh-select>
+<jh-select label="Account type" helper-text="Choose an account" .options=${myOptions} value="checking-01"></jh-select>
 ```
 
 In situations where the above approach is not available, authors can use an imperative API to set options and other properties via JavaScript:
@@ -41,6 +41,7 @@ In situations where the above approach is not available, authors can use an impe
 ```javascript
 const select = document.querySelector('jh-select');
 select.options = myOptions;
+select.value = 'checking-01';
 ```
 
 ## Options Data Format
@@ -49,9 +50,10 @@ Authors must provide the options as an array of objects to the `.options` proper
 
 - Each option object must include a unique `value` string and a `label` string for display.
 - If no `label` is provided, the `value` will be used as the display text in the menu and input. 
-- An empty option can be included by providing an option object with a `label` string and an empty string for the `value`. 
 - Options can be made disabled by setting the `disabled: true` flag. 
-- Flag an option as `selected: true` to set it as the default option showing in the input field.
+- Flag an option as `selected: true` to set the initial default when no `value` is provided. 
+Once a `value` is set — either by the author or by user interaction — the `selected` flag is ignored. Use the `value` attribute or property to control the selected option.
+- An empty option can be included by providing an `option` object with a `label` string and an empty string for the `value` (e.g. `{ label: "Select a state...", value: "" }`). 
 
 Options can be provided in a flat structure or grouped by category: 
 - Flat options are displayed as `jh-list-item` elements, 
@@ -81,6 +83,47 @@ const groupedOptions = [
   ]},
 ];
 ```
+
+## Setting the Value
+
+### Initial value
+There are two ways to set the initial selected option:
+
+**Using the `value` attribute** (recommended) — set the `value` attribute to match an option's `value`:
+
+```html
+<jh-select label="Account type" value="checking-01" .options=${myOptions}></jh-select>
+```
+
+**Using the `selected` flag** — flag an option as `selected: true` in the options array. This only applies on initial render and when no `value` attribute is set:
+
+```javascript
+const myOptions = [
+  { label: "Basic Checking", value: "checking-01", selected: true },
+  { label: "High-Yield Savings", value: "savings-01" },
+];
+<jh-select label="Account type" .options=${myOptions}></jh-select>
+```
+
+### Placeholder options
+An empty option can be used as a placeholder — include an option with `value: ""` and a descriptive label. To display it on initial render, either set `value=""` on the select or set the `selected` flag on the placeholder option:
+
+```html
+<jh-select label="State" value="" .options=${stateOptions}></jh-select>
+```
+
+### Changing the value programmatically
+To change the selected value programmatically after initialization, set the value property:
+
+```javascript
+const select = document.querySelector('jh-select');
+select.value = 'savings-01';
+```
+
+To clear the selection, set value to null.
+
+**Note:** Setting value programmatically does not dispatch the `jh-change` event. Only user interactions dispatch events.
+
 ## Using the jh-datasets package with jh-select
 
 The datasets package provides a set of common datasets in the correct format for use with the jh-select component. 

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -414,17 +414,14 @@ export const ProgrammaticValueChange = {
     const setSelected = (selectedValue) => {
       const select = document.querySelector('#programmatic-select');
       if (select) {
-        select.options = baseOptions.map((opt) => ({
-          ...opt,
-          selected: opt.value === selectedValue,
-        }));
-      } 
+        select.value = selectedValue;
+      }
     };
 
     const clearSelected = () => {
       const select = document.querySelector('#programmatic-select');
       if (select) {
-        select.options = baseOptions.map((opt) => ({ ...opt, selected: false }));
+        select.value = '';
       }
     };
 
@@ -433,7 +430,8 @@ export const ProgrammaticValueChange = {
         <jh-select
           id="programmatic-select"
           label="Programmatic value change"
-          helper-text="Use the buttons below to change the selected option via .options"
+          helper-text="Use the buttons below to change the selected option via .value"
+          .value=${'cd'}
           .options=${baseOptions}
         ></jh-select>
         <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px;">

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -17,6 +17,7 @@ import { US_STATES_GROUPED } from '@jack-henry/jh-datasets/datasets/us-states-gr
 import { manageSelectDataset } from '@jack-henry/jh-datasets/utils/manageDataset.js';
 
 const testOptions = [
+  { label: "select a value...", value: "" },
   { groupLabel: "Account types", groupValues: [
     {  value: "checking-01" },
     {  value: "savings-01", disabled: true },
@@ -32,7 +33,7 @@ const testOptions = [
   { label: "Certificate of Deposit", value: "cd-12-month" },
   { label: "IRA Investment", value: "ira-traditional" },
   { label: "Health Savings Account", value: "hsa-01" },
-  { label: "Brokerage Account", value: "brokerage-standard" }
+  { label: "Brokerage Account", value: "brokerage-standard" },
 ];
 
 const storyStyles = css`
@@ -67,6 +68,7 @@ const disableControls = {
   required: { control: { disable: true } },
   'show-indicator': { control: { disable: true } },
   size: { control: { disable: true } },
+  value: { control: { disable: true } },
   'flip-disabled': { control: { disable: true } },
 }
 
@@ -145,8 +147,7 @@ export default {
       description: 'Sets the size of the select.',
     },
     value: {
-      description: 'Sets the value of the select.',
-      table: { disable: true }
+      description: 'Sets the value of the select programmatically.',
     },
     'flip-disabled': { control: 'boolean' },
     // Hide inherited jh-input slots
@@ -232,6 +233,7 @@ export const Playground = { render: (args) => html`
     size=${args.size}
     ?flip-disabled=${args['flip-disabled']}
     .options=${testOptions}
+    value=${args.value}
   ></jh-select>
   </div>`
 };
@@ -255,10 +257,12 @@ Playground.args = {
   'show-indicator': false,
   size: 'medium',
   'flip-disabled': false,
+  value: "",
 };
 
 Playground.argTypes = {
   options: { control: { disable: true } },
+  value: { control: { disable: true } },
 };
 
 Playground.parameters = {

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -17,7 +17,7 @@ import { US_STATES_GROUPED } from '@jack-henry/jh-datasets/datasets/us-states-gr
 import { manageSelectDataset } from '@jack-henry/jh-datasets/utils/manageDataset.js';
 
 const testOptions = [
-  { label: "select a value...", value: "" },
+  { label: "select a value...", value: "", selected: true },
   { groupLabel: "Account types", groupValues: [
     {  value: "checking-01" },
     {  value: "savings-01", disabled: true },
@@ -25,7 +25,7 @@ const testOptions = [
   ]},
   { groupLabel: "Credit Cards", groupValues: [
     { label: "Cash Back Rewards with a much longer label for testing", value: "cc-cash-back" },
-    { label: "Travel Rewards", value: "cc-travel", selected: true },
+    { label: "Travel Rewards", value: "cc-travel" },
     { label: "Low Interest", value: "cc-low-interest" },
   ]},
   { label: "Personal Loan", value: "loan-personal" },
@@ -207,7 +207,7 @@ export default {
 };
 
 export const Overview = { render: (args) => html`
-  <jh-select .options=${testOptions} label="Select an account" helper-text="The accounts are grouped by type"></jh-select>
+  <jh-select .options=${testOptions} label="Select an account" helper-text="The accounts are grouped by type" value="cc-travel"></jh-select>
 `};
 
 Overview.argTypes = {
@@ -321,7 +321,7 @@ export const MenuFlip = { render: (args) => html`
       <jh-select label="Top select" .options=${testOptions} helper-text="should open on bottom" menu-position="top" invalid error-text="Error text"></jh-select>
     </div>
     <div>
-      <jh-select label="Bottom select" helper-text="should open on top" .options=${testOptions}  invalid error-text="Error text" menu-position="bottom"></jh-select>
+      <jh-select label="Bottom select" helper-text="should open on top" .options=${testOptions}  invalid error-text="Error text" menu-position="bottom" value="cc-travel"></jh-select>
     </div>
   </div>
 `};
@@ -375,6 +375,7 @@ export const FormAssociated = {
           label=${args.label}
           ?required=${args.required}
           .options=${testOptions}
+          value="checking-01"
         ></jh-select>
         <jh-button label="Submit" submit @click=${onClick}></jh-button>
       </form>
@@ -425,7 +426,7 @@ export const ProgrammaticValueChange = {
     const clearSelected = () => {
       const select = document.querySelector('#programmatic-select');
       if (select) {
-        select.value = '';
+        select.value = null;
       }
     };
 
@@ -435,7 +436,7 @@ export const ProgrammaticValueChange = {
           id="programmatic-select"
           label="Programmatic value change"
           helper-text="Use the buttons below to change the selected option via .value"
-          .value=${'cd'}
+          value="cd"
           .options=${baseOptions}
         ></jh-select>
         <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px;">

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -402,5 +402,57 @@ FormAssociated.parameters = {
   styles: storyStyles,
 };
 
+export const ProgrammaticValueChange = {
+  render: () => {
+    const baseOptions = [
+      { label: 'Checking', value: 'checking' },
+      { label: 'Savings', value: 'savings' },
+      { label: 'Money Market', value: 'money-market' },
+      { label: 'Certificate of Deposit', value: 'cd' },
+    ];
 
+    const setSelected = (selectedValue) => {
+      const select = document.querySelector('#programmatic-select');
+      if (select) {
+        select.options = baseOptions.map((opt) => ({
+          ...opt,
+          selected: opt.value === selectedValue,
+        }));
+      } 
+    };
+
+    const clearSelected = () => {
+      const select = document.querySelector('#programmatic-select');
+      if (select) {
+        select.options = baseOptions.map((opt) => ({ ...opt, selected: false }));
+      }
+    };
+
+    return html`
+      <div class="select-container">
+        <jh-select
+          id="programmatic-select"
+          label="Programmatic value change"
+          helper-text="Use the buttons below to change the selected option via .options"
+          .options=${baseOptions}
+        ></jh-select>
+        <div style="display: flex; gap: 8px; flex-wrap: wrap; margin-top: 12px;">
+          <jh-button label="Select 'checking'" @click=${() => setSelected('checking')}></jh-button>
+          <jh-button label="Select 'savings'" @click=${() => setSelected('savings')}></jh-button>
+          <jh-button label="Select 'money-market'" @click=${() => setSelected('money-market')}></jh-button>
+          <jh-button label="Select 'cd'" @click=${() => setSelected('cd')}></jh-button>
+          <jh-button label="Clear selection" appearance="secondary" @click=${() => clearSelected()}></jh-button>
+        </div>
+      </div>
+    `;
+  },
+};
+
+ProgrammaticValueChange.argTypes = {
+  ...disableControls,
+};
+
+ProgrammaticValueChange.parameters = {
+  styles: storyStyles,
+};
 


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

A bug was reported that the value set on the select cannot be altered programmatically. To fix this we have added support for the `value` attribute on `jh-select`. The `selected` flag on the `.options` array now only serves to set the initial value of the select. This change makes the functionality more intuitive and similar to the native select.

Docs and stories have been updated to reflect the changes made.

**Idea number or other reference :**  bug fix

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies