### PR TITLE
[Table] add min-width to scrollable table

### DIFF
--- a/packages/jh-elements/components/table/table.js
+++ b/packages/jh-elements/components/table/table.js
@@ -187,6 +187,7 @@ export class JhTable extends JhElement {
       :host([scrollable]) .table {
         width: auto;
         position: relative;
+        min-width: 100%;
       }
       .table-wrapper:has(.table-container:focus-visible) {
         outline-color: var(


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It fixes a bug where the scrollable table would shrink to fit the content instead of filling 100% of the available width. 

**Idea number or other reference :** Bug fix

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

Remove some columns from the scrollable story to ensure the table fills 100% of available space.

## Notes/Dependencies