### PR TITLE
[Next] Update migration docs with list-item changes

### DIFF
--- a/packages/jh-ui/docs/whats-new/jh-elements.mdx
+++ b/packages/jh-ui/docs/whats-new/jh-elements.mdx
@@ -88,9 +88,6 @@ A detailed list of [jh-input deprecated styling hooks](/docs/what-s-new-migratin
 ### jh-icon
 The `jh-icon` component now supports a new `xx-large` sizing option, along with a corresponding styling hook (`--jh-icon-size-extra-extra-large`) for easy overrides.
 
-### jh-progress
-The `jh-progress` component now supports three new size variants: `x-small`, `x-large`, and `xx-large`. A `--jh-progress-track-size-circular` styling hook has been added to customize circular progress dimensions, while the `--jh-progress-track-size-linear` hook overrides the height of linear progress bars. The thickness of the circular progress line now scales automatically to align with the corresponding icon stroke widths.
-
 ### jh-list-item
 
 In version 1, the text in `jh-list-item` would atuomatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
@@ -101,6 +98,9 @@ We have also added styling hooks to adjust the padding and text color of the lis
 ### jh-menu
 
 The jh-menu component now features an improved menu-content container with `overflow-y: auto` and full-width flex styling. These additions ensure the menu remains scrollable and responsive within its parent container without breaking the layout. 
+
+### jh-progress
+The `jh-progress` component now supports three new size variants: `x-small`, `x-large`, and `xx-large`. A `--jh-progress-track-size-circular` styling hook has been added to customize circular progress dimensions, while the `--jh-progress-track-size-linear` hook overrides the height of linear progress bars. The thickness of the circular progress line now scales automatically to align with the corresponding icon stroke widths.
 
 ### jh-radio
 The label typography tokens have changed from `--jh-font-body-regular-1-...` to `--jh-font-body-medium-1-...`.

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -567,12 +567,12 @@ Alternatively, the `primary-text`, `secondary-text`, `primary-metadata`, and `se
     <tr>
       <td>`--jh-list-item-metadata-color-text-primary`</td>
       <td>CSS Hook</td>
-      <td>Migrate to `--jh-list-item-metadata-color-text-primary-enabled`</td>
+      <td>Migrate to `--jh-list-item-metadata-color-text-primary-enabled`.</td>
     </tr>
     <tr>
       <td>`--jh-list-item-metadata-color-text-secondary`</td>
       <td>CSS Hook</td>
-      <td>Migrate to`--jh-list-item-metadata-color-text-secondary-enabled`</td>
+      <td>Migrate to `--jh-list-item-metadata-color-text-secondary-enabled`.</td>
     </tr>
     <tr>
       <td>`--jh-list-item-color-text`</td>

--- a/packages/jh-ui/docs/whats-new/migrating.mdx
+++ b/packages/jh-ui/docs/whats-new/migrating.mdx
@@ -542,7 +542,8 @@ The `placeholder` property has been deprecated due to accessibility concerns. Pl
 * `--jh-input-left-icon-color-fill` and `--jh-input-left-icon-color-fill` are deprecated, use the icon styling hook `--jh-icon-color-fill` instead. 
 
 ### Migrating jh-list-item
-The `jh-list-item` component has been simplified. Please update your code to remove the deprecated properties, hooks, and slots listed below.
+The `jh-list-item` component has been simplified. The `jh-list-item-content` and `jh-list-item-metadata` slots have been removed, in favor of a more streamlined layout that uses the `default` slot along with the  `jh-list-item-left`, and `jh-list-item-right` slots.
+Alternatively, the `primary-text`, `secondary-text`, `primary-metadata`, and `secondary-metadata` properties can be used alone or in combination with the left and right slots.
 
 <table>
   <thead>
@@ -554,24 +555,24 @@ The `jh-list-item` component has been simplified. Please update your code to rem
   </thead>
   <tbody>
     <tr>
-      <td>`primary-metadata`</td>
-      <td>Property</td>
+      <td>`jh-list-item-content`</td>
+      <td>Slot</td>
       <td>Remove and migrate to new layout pattern.</td>
     </tr>
     <tr>
-      <td>`secondary-metadata`</td>
-      <td>Property</td>
+      <td>`jh-list-item-metadata`</td>
+      <td>Slot</td>
       <td>Remove and migrate to new layout pattern.</td>
     </tr>
     <tr>
       <td>`--jh-list-item-metadata-color-text-primary`</td>
       <td>CSS Hook</td>
-      <td>Remove reference.</td>
+      <td>Migrate to `--jh-list-item-metadata-color-text-primary-enabled`</td>
     </tr>
     <tr>
       <td>`--jh-list-item-metadata-color-text-secondary`</td>
       <td>CSS Hook</td>
-      <td>Remove reference.</td>
+      <td>Migrate to`--jh-list-item-metadata-color-text-secondary-enabled`</td>
     </tr>
     <tr>
       <td>`--jh-list-item-color-text`</td>
@@ -587,16 +588,6 @@ The `jh-list-item` component has been simplified. Please update your code to rem
       <td>`--jh-list-item-color-text-secondary`</td>
       <td>CSS Hook</td>
       <td>Migrate to `--jh-list-item-color-text-secondary-enabled`.</td>
-    </tr>
-    <tr>
-      <td>`jh-list-item-content`</td>
-      <td>Slot</td>
-      <td>Remove and migrate to new layout pattern.</td>
-    </tr>
-    <tr>
-      <td>`jh-list-item-metadata`</td>
-      <td>Slot</td>
-      <td>Remove and migrate to new layout pattern.</td>
     </tr>
   </tbody>
 </table>


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It updates the migration guide to list-item now that we are reintroducing the metadata properties.
Reorders the list of components in the guide alphabetically.

**Idea number or other reference :** N/A

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

## Notes/Dependencies