### PR TITLE
[Tag] Add dismissMethod property to jh-dismiss event

### DIFF
--- a/.changeset/mighty-snakes-type.md
+++ b/.changeset/mighty-snakes-type.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[tag] adds dismiss method property to jh-dismiss method.

--- a/packages/jh-elements/components/tag/tag.js
+++ b/packages/jh-elements/components/tag/tag.js
@@ -40,7 +40,7 @@ import '../tooltip/tooltip.js';
  *
  * @slot jh-tag-icon - Use to insert an icon to the left of the tag.
  * @slot jh-tag-dismiss-icon - Use to insert a custom icon within the dismiss button.
- * @event jh-dismiss - Dispatched when the tag is dismissed.
+ * @event jh-dismiss - Dispatched when the tag is dismissed. Event payload includes the dismissal method of the tag and can be accessed via `e.detail.reference.dismissMethod`
  * @customElement jh-tag
  */
 export class JhTag extends JhElement {
@@ -358,7 +358,16 @@ export class JhTag extends JhElement {
 
   #handleDismissal(e) {
     e.stopPropagation();
-    this.dispatchCustomEvent('jh-dismiss');
+    
+    let dismissMethod = 'unknown';
+
+    if (e.pointerType) {
+      dismissMethod = e.pointerType;
+    } else if (e.detail === 0) {
+      dismissMethod = 'keyboard';
+    }
+    
+    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod } });
 
     if (this.removeOnDismiss) {
       this.remove();

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -7402,7 +7402,7 @@
       "events": [
         {
           "name": "jh-dismiss",
-          "description": "Dispatched when the tag is dismissed."
+          "description": "Dispatched when the tag is dismissed. Event payload includes the dismissal method of the tag and can be accessed via `e.detail.reference.dismissMethod`"
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds `e.detail.reference.dismissMethod` to `jh-dismiss` event payload. 

**Idea number or other reference :** 181

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

Activate dismiss button via mouse and keyboard and ensure that appropriate value is rendered in the `jh-dismiss` event payload. 

## Notes/Dependencies

n/a


