### PR TITLE
[Toast and Notification] Add dismissMethod property to jh-dismiss event

### DIFF
--- a/.changeset/twelve-terms-fix.md
+++ b/.changeset/twelve-terms-fix.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[toast and notification] adds dismiss method property to jh-change event"

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -56,7 +56,7 @@ import '@jack-henry/jh-icons/icons-wc/icon-xmark.js';
  * @slot jh-notification-icon - Use to insert a button or icon to the left of the default slot. 
  * @slot jh-notification-dismiss-icon - Use to insert icon within the dismiss button. 
  * @slot jh-notification-action - Use to insert action button(s). Placed to the right of the default slot. Set `stacked` property to place slot below default slot. 
- * @event jh-dismiss - Dispatched when the notification is dismissed.
+ * @event jh-dismiss - Dispatched when the notification is dismissed. Event payload includes the dismissal method of the notification and can be accessed via `e.detail.reference.dismissMethod`
  *
  * @customElement jh-notification
  */
@@ -253,8 +253,14 @@ export class JhNotification extends JhElement {
     this.type = 'alert';
   }
 
-  #handleDismissal() {
-    this.dispatchCustomEvent('jh-dismiss');
+  #handleDismissal(e) {
+    let dismissMethod = 'unknown';
+    if (e.pointerType) {
+      dismissMethod = 'mouse';
+    } else if (e.detail === 0) {
+      dismissMethod = 'keyboard';
+    }
+    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod } });
     // if notification is wrapped by jh-toast component, do not remove notification from DOM
     if (this.parentNode.host?.nodeName === 'JH-TOAST') {
       return;

--- a/packages/jh-elements/components/notification/notification.js
+++ b/packages/jh-elements/components/notification/notification.js
@@ -255,16 +255,19 @@ export class JhNotification extends JhElement {
 
   #handleDismissal(e) {
     let dismissMethod = 'unknown';
+
     if (e.pointerType) {
       dismissMethod = 'mouse';
     } else if (e.detail === 0) {
       dismissMethod = 'keyboard';
     }
-    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod } });
+
     // if notification is wrapped by jh-toast component, do not remove notification from DOM
     if (this.parentNode.host?.nodeName === 'JH-TOAST') {
+      this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod: dismissMethod, originHost: 'jh-toast' } });
       return;
     } else {
+      this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod } });
       this.remove();
     }   
   }

--- a/packages/jh-elements/components/toast/toast.js
+++ b/packages/jh-elements/components/toast/toast.js
@@ -115,7 +115,7 @@ export class JhToast extends JhElement {
   }
 
   #removeToast() {
-    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod: 'timeout' } });
+    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod: 'timeout'} });
   }
 
   #handleDismiss() {

--- a/packages/jh-elements/components/toast/toast.js
+++ b/packages/jh-elements/components/toast/toast.js
@@ -13,7 +13,7 @@ import '../notification/notification.js';
  * @slot jh-toast-icon - Use to insert a button or icon to the left of the default slot.
  * @slot jh-toast-dismiss-icon - Use to insert icon within the dismiss button.
  * @slot jh-toast-action - Use to insert action button(s). Placed to the right of the default slot. Set `stacked` property to place slot below default slot.
- * @event jh-dismiss - Dispatched when the toast is dismissed.
+ * @event jh-dismiss - Dispatched when the toast is dismissed. Event payload includes the dismissal method of the toast and can be accessed via `e.detail.reference.dismissMethod`
  * @customElement jh-toast
  */
 export class JhToast extends JhElement {
@@ -115,7 +115,7 @@ export class JhToast extends JhElement {
   }
 
   #removeToast() {
-    this.dispatchCustomEvent('jh-dismiss');
+    this.dispatchCustomEvent('jh-dismiss', { reference: { dismissMethod: 'timeout' } });
   }
 
   #handleDismiss() {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5117,7 +5117,7 @@
       "events": [
         {
           "name": "jh-dismiss",
-          "description": "Dispatched when the notification is dismissed."
+          "description": "Dispatched when the notification is dismissed. Event payload includes the dismissal method of the notification and can be accessed via `e.detail.reference.dismissMethod`"
         }
       ],
       "slots": [
@@ -7642,7 +7642,7 @@
       "events": [
         {
           "name": "jh-dismiss",
-          "description": "Dispatched when the toast is dismissed."
+          "description": "Dispatched when the toast is dismissed. Event payload includes the dismissal method of the toast and can be accessed via `e.detail.reference.dismissMethod`"
         }
       ],
       "slots": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds `e.detail.reference.dismissMethod` to `jh-toast` and `jh-notification` `jh-dismiss` event payload.

**Idea number or other reference :** 181

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a


