### PR TITLE
[Switch] Adds checked property to jh-change event

### DIFF
--- a/.changeset/ten-falcons-whisper.md
+++ b/.changeset/ten-falcons-whisper.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[switch] adds checked property to jh-change event.

--- a/packages/jh-elements/components/switch/switch.js
+++ b/packages/jh-elements/components/switch/switch.js
@@ -23,7 +23,7 @@ import { JhElement } from '../element/element.js';
  * @cssprop --jh-switch-track-color-background-selected-active - The track color when selected and active. Defaults to `--jh-color-content-brand-active`.
  * @cssprop --jh-switch-track-color-background-selected-disabled - The track color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the switch has changed.
+ * @event jh-change - Dispatched when the state of the switch has changed. Event payload includes the `checked` state of the switch and can be accessed via `e.detail.state.checked`.
  *
  * @customElement jh-switch
  */
@@ -253,7 +253,7 @@ export class JhSwitch extends JhElement {
   #handleClick() {
     if (!this.disabled && this.accessibleDisabled !== 'true') {
       this.checked = !this.checked;
-      this.dispatchCustomEvent('jh-change');
+      this.dispatchCustomEvent('jh-change', { state: { checked: this.checked } });
     }
   }
 

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -6614,7 +6614,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the switch has changed."
+          "description": "Dispatched when the state of the switch has changed. Event payload includes the `checked` state of the switch and can be accessed via `e.detail.state.checked`."
         }
       ],
       "cssProperties": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds `e.detail.state.checked` to `jh-switch` `jh-change` event payload.

**Idea number or other reference :** 181

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a


