### PR TITLE
[Radio] adds checked property to change event

### DIFF
--- a/.changeset/small-ads-share.md
+++ b/.changeset/small-ads-share.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[radio] adds checked property to jh-change event.

--- a/packages/jh-elements/components/radio/radio.js
+++ b/packages/jh-elements/components/radio/radio.js
@@ -59,7 +59,7 @@ import { JhElement } from '../element/element.js';
  * Defaults to `--jh-border-control-color`.
  * @cssprop --jh-radio-status-color-background-selected-disabled - The status mark color when selected and disabled. Defaults to `--jh-color-content-brand-enabled`.
  *
- * @event jh-change - Dispatched when the state of the radio has changed. Event payload includes the value of the radio and can be accessed via `e.detail.state.value`. 
+ * @event jh-change - Dispatched when the state of the radio has changed. Event payload includes the value and checked state of the radio and can be accessed via `e.detail.state.value` and `e.detail.state.checked`. 
  *
  * @customElement jh-radio */
 
@@ -370,7 +370,7 @@ export class JhRadio extends JhElement {
     if (this.checked) return;
 
     this.checked = true;
-    this.dispatchCustomEvent('jh-change');
+    this.dispatchCustomEvent('jh-change', {state: { checked: this.checked }});
   }
 
   #handleKeydown(e) {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5753,7 +5753,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Dispatched when the state of the radio has changed. Event payload includes the value of the radio and can be accessed via `e.detail.state.value`."
+          "description": "Dispatched when the state of the radio has changed. Event payload includes the value and checked state of the radio and can be accessed via `e.detail.state.value` and `e.detail.state.checked`."
         }
       ],
       "cssProperties": [


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds `e.detail.state.checked` to `jh-radio` `jh-change` event payload.

**Idea number or other reference :** 181

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a
