### PR TITLE
[Checkbox Group] Adds jh-change event and related event properties

### DIFF
--- a/.changeset/thirty-falcons-listen.md
+++ b/.changeset/thirty-falcons-listen.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[checkbox-group] adds jh-chnage event and related event properties.

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -269,7 +269,7 @@ export class JhCheckboxGroup extends JhElement {
   #getPreviousValues() {
     const previousSelectedValue = [...this.#previousSelectedValue];
     const selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
-        .filter(checkbox => checkbox.checked)
+        .filter(checkbox => checkbox.checked && !checkbox.indeterminate)
         .map(checkbox => checkbox.value);
 
     this.#previousSelectedValue = [...selectedValues];

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -19,13 +19,16 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @cssprop --jh-checkbox-group-error-color-text - The error-text text color.
  * Defaults to `--jh-color-content-negative-enabled`.
  * 
- * @event jh-change - Fired when the selection of checkboxes changes. Event payload includes the the selected checkbox values and can be accessed via `e.detail.state.selectedValue`.
+ * @event jh-change - Fired when the selection of checkboxes changes. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`.
  *
  * @slot default - Use to insert `<jh-checkbox>` component(s).
  *
  * @customElement jh-checkbox-group
  */
 export class JhCheckboxGroup extends JhElement {
+  #previousSelectedValue = [];
+
+
   static get styles() {
     return css`
       :host {
@@ -244,13 +247,21 @@ export class JhCheckboxGroup extends JhElement {
     }
   }
 
-    #handleChange(e) {
+  #handleChange(e) {
     if (e.detail.reference.originHost === 'jh-checkbox') {
-      let selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
+      const previousSelectedValue = [...this.#previousSelectedValue];
+      const selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
         .filter(checkbox => checkbox.checked)
         .map(checkbox => checkbox.value);
-   
-      this.dispatchCustomEvent('jh-change', { state: { selectedValue: selectedValues }} );
+
+      this.#previousSelectedValue = [...selectedValues];
+
+      this.dispatchCustomEvent('jh-change', {
+        state: {
+          previousSelectedValue,
+          selectedValue: selectedValues,
+        },
+      });
     }
   }
 

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -18,6 +18,8 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * Defaults to `--jh-color-content-secondary-enabled`.
  * @cssprop --jh-checkbox-group-error-color-text - The error-text text color.
  * Defaults to `--jh-color-content-negative-enabled`.
+ * 
+ * @event jh-change - Fired when the selection of checkboxes changes. Event payload includes the the selected checkbox values and can be accessed via `e.detail.state.selectedValue`.
  *
  * @slot default - Use to insert `<jh-checkbox>` component(s).
  *
@@ -206,6 +208,7 @@ export class JhCheckboxGroup extends JhElement {
     this.orientation = 'vertical';
     /** @type {?boolean} */
     this.showIndicator = false;
+    this.addEventListener('jh-change', this.#handleChange);
   }
 
   firstUpdated() {
@@ -238,6 +241,16 @@ export class JhCheckboxGroup extends JhElement {
       return `checkbox-group-error-${this.uniqueId}`;
     } else if (this.helperText && this.label) {
       return `checkbox-group-helper-${this.uniqueId}`;
+    }
+  }
+
+    #handleChange(e) {
+    if (e.detail.reference.originHost === 'jh-checkbox') {
+      let selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.value);
+   
+      this.dispatchCustomEvent('jh-change', { state: { selectedValue: selectedValues }} );
     }
   }
 

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -217,12 +217,18 @@ export class JhCheckboxGroup extends JhElement {
   firstUpdated() {
     const slot = this.renderRoot?.querySelector('slot');
     this.#syncDisabledToChildren();
+    this.#getPreviousValues();
   }
 
   updated(changedProperties) {
     if (changedProperties.has('disabled')) {
       this.#syncDisabledToChildren();
     }
+  }
+
+  #handleSlotChange() {
+    this.#syncDisabledToChildren();
+    this.#getPreviousValues();
   }
 
   #syncDisabledToChildren() {
@@ -249,12 +255,7 @@ export class JhCheckboxGroup extends JhElement {
 
   #handleChange(e) {
     if (e.detail.reference.originHost === 'jh-checkbox') {
-      const previousSelectedValue = [...this.#previousSelectedValue];
-      const selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
-        .filter(checkbox => checkbox.checked)
-        .map(checkbox => checkbox.value);
-
-      this.#previousSelectedValue = [...selectedValues];
+      const { previousSelectedValue, selectedValues } = this.#getPreviousValues();
 
       this.dispatchCustomEvent('jh-change', {
         state: {
@@ -263,6 +264,17 @@ export class JhCheckboxGroup extends JhElement {
         },
       });
     }
+  }
+
+  #getPreviousValues() {
+    const previousSelectedValue = [...this.#previousSelectedValue];
+    const selectedValues = Array.from(this.querySelectorAll('jh-checkbox'))
+        .filter(checkbox => checkbox.checked)
+        .map(checkbox => checkbox.value);
+
+    this.#previousSelectedValue = [...selectedValues];
+
+    return { previousSelectedValue, selectedValues };
   }
 
   render() {
@@ -304,7 +316,7 @@ export class JhCheckboxGroup extends JhElement {
         aria-disabled=${ifDefined(this.disabled ? 'true' : null)}
         aria-label=${ifDefined(this.accessibleLabel)}>
         ${label}
-        <div class="controls"><slot @slotchange=${() => this.#syncDisabledToChildren()} ></slot></div>
+        <div class="controls"><slot @slotchange=${this.#handleSlotChange}></slot></div>
         ${errorText}
       </fieldset>
     `;

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.js
@@ -19,7 +19,7 @@ import { ifDefined } from 'lit/directives/if-defined.js';
  * @cssprop --jh-checkbox-group-error-color-text - The error-text text color.
  * Defaults to `--jh-color-content-negative-enabled`.
  * 
- * @event jh-change - Fired when the selection of checkboxes changes. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`.
+ * @event jh-change - Fired when the selection of checkboxes is changed by the user. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`.
  *
  * @slot default - Use to insert `<jh-checkbox>` component(s).
  *

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
@@ -100,16 +100,19 @@ export const Overview = {
           label="checkbox 1"
           helper-text="Helper text"
           name="checkbox-1"
+          value="value-1"
         ></jh-checkbox>
         <jh-checkbox
           label="checkbox 2"
           helper-text="Helper text"
           name="checkbox-2"
+          value="value-2"
         ></jh-checkbox>
         <jh-checkbox
           label="checkbox 3"
           helper-text="Helper text"
           name="checkbox-3"
+          value="value-3"
           checked
         ></jh-checkbox>
       </jh-checkbox-group>
@@ -121,13 +124,14 @@ export const Overview = {
         orientation="horizontal"
         disabled
       >
-        <jh-checkbox label="checkbox 4" name="checkbox-4"></jh-checkbox>
+        <jh-checkbox label="checkbox 4" name="checkbox-4" value="value-4"></jh-checkbox>
         <jh-checkbox
           label="checkbox 5"
           name="checkbox-5"
+          value="value-5"
           disabled
         ></jh-checkbox>
-        <jh-checkbox label="checkbox 6" name="checkbox-6"></jh-checkbox>
+        <jh-checkbox label="checkbox 6" name="checkbox-6" value="value-6"></jh-checkbox>
       </jh-checkbox-group>
     </div>
     <div class="container">
@@ -138,13 +142,13 @@ export const Overview = {
         error-text="Error text"
         invalid
       >
-        <jh-checkbox label="checkbox 4" name="checkbox-4"></jh-checkbox>
+        <jh-checkbox label="checkbox 4" name="checkbox-4" value="value-7"></jh-checkbox>
         <jh-checkbox
           label="checkbox 5"
           name="checkbox-5"
           disabled
-        ></jh-checkbox>
-        <jh-checkbox label="checkbox 6" name="checkbox-6"></jh-checkbox>
+        value="checkbox-5"></jh-checkbox>
+        <jh-checkbox label="checkbox 6" name="checkbox-6" value="value-8"></jh-checkbox>
       </jh-checkbox-group>
     </div>`,
 };
@@ -238,6 +242,7 @@ export const FormAssociated = {
             label="checkbox 3"
             helper-text="Helper text"
             name="checkbox-3"
+            value="value-3"
           ></jh-checkbox>
         </jh-checkbox-group>
         <jh-button label="Submit" submit @click=${onClick}></jh-button>

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
@@ -171,21 +171,25 @@ export const Playground = {
       <jh-checkbox
         label="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur metus massa, mollis euismod lorem ut, tincidunt dignissim ex."
         name="checkbox-1"
+        value="value-1"
         helper-text="Helper text"
       ></jh-checkbox>
       <jh-checkbox
         label="Label"
         name="checkbox-2"
+        value="value-2"
         helper-text="Helper text"
       ></jh-checkbox>
       <jh-checkbox
         label="Lorem ipsum dolor sit amet, consectetur adipiscing elit."
         name="checkbox-3"
+        value="value-3"
         helper-text="Helper text"
       ></jh-checkbox>
       <jh-checkbox
         label="Slightly longer label"
         name="checkbox-3"
+        value="value-4"
         helper-text="Helper text"
       ></jh-checkbox>
     </jh-checkbox-group>

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
@@ -173,9 +173,11 @@ export const Playground = {
         name="checkbox-1"
         value="value-1"
         helper-text="Helper text"
+        checked
       ></jh-checkbox>
       <jh-checkbox
         label="Label"
+        indeterminate
         name="checkbox-2"
         value="value-2"
         helper-text="Helper text"

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.stories.js
@@ -178,6 +178,7 @@ export const Playground = {
       <jh-checkbox
         label="Label"
         indeterminate
+        checked
         name="checkbox-2"
         value="value-2"
         helper-text="Helper text"

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -917,7 +917,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Fired when the selection of checkboxes changes. Event payload includes the the selected checkbox values and can be accessed via `e.detail.state.selectedValue`."
+          "description": "Fired when the selection of checkboxes changes. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`."
         }
       ],
       "slots": [

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -917,7 +917,7 @@
       "events": [
         {
           "name": "jh-change",
-          "description": "Fired when the selection of checkboxes changes. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`."
+          "description": "Fired when the selection of checkboxes is changed by the user. Event payload includes both current and previous selections, accessible via `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`."
         }
       ],
       "slots": [

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -914,6 +914,12 @@
           "type": "number"
         }
       ],
+      "events": [
+        {
+          "name": "jh-change",
+          "description": "Fired when the selection of checkboxes changes. Event payload includes the the selected checkbox values and can be accessed via `e.detail.state.selectedValue`."
+        }
+      ],
       "slots": [
         {
           "name": "default",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Adds `jh-change` event to the `checkbox-group` component, along with the following event properties: `e.detail.state.selectedValue` and `e.detail.state.previousSelectedValue`. 

**Idea number or other reference :** 181

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

n/a

## Notes/Dependencies

n/a


