### PR TITLE
Remove GITHUB_TOKEN from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -34,8 +34,6 @@ jobs:
       - name: Publish Packages
         id: changesets
         uses: changesets/action@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           publish: pnpm run changeset:release
           createGithubReleases: true


### PR DESCRIPTION
Removed GITHUB_TOKEN from Publish Packages step.

<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

_What is the purpose of this pull request?_

**Idea number or other reference :** _add relevant idea number_

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

_add any other details on how to test_ 

## Notes/Dependencies

- _Are there remaining issues or things this PR hasn't solved yet?_ 
- _Are there any long-term implications?_
- _Are there any dependencies to other PRs_


