### PR TITLE
fix(badge): sizing, numerals, and placement docs

### DIFF
--- a/.changeset/badge-sizing-and-numerals.md
+++ b/.changeset/badge-sizing-and-numerals.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": patch
+---
+
+[badge] corrects vertical centering, keeps single-digit counts circular, and stabilizes width across counts with tabular numerals.

--- a/.changeset/badge-sizing-and-numerals.md
+++ b/.changeset/badge-sizing-and-numerals.md
@@ -2,4 +2,4 @@
 "@jack-henry/jh-elements": patch
 ---
 
-[badge] corrects vertical centering, keeps single-digit counts circular, and stabilizes width across counts with tabular numerals.
+[badge] fixes single-digit badges rendering oval and stabilizes multi-digit width. Rendered badge width changes: a single-digit count is now a 16x16 circle rather than ~15x16, and multi-digit counts no longer shift width depending on which digits are shown. Vertical centering of the count is now explicit rather than incidental.

--- a/packages/jh-elements/components/badge/badge.js
+++ b/packages/jh-elements/components/badge/badge.js
@@ -23,17 +23,21 @@ export class JhBadge extends JhElement {
       background: var(--jh-badge-color-background-enabled, var(--jh-color-content-negative-enabled));
       color: var(--jh-badge-color-text-enabled, var(--jh-color-content-on-negative-enabled));
       border-radius: var(--jh-badge-border-radius, var(--jh-border-radius-pill));
+      box-sizing: border-box;
       min-width: var(--jh-dimension-200);
       height: var(--jh-dimension-200);
       display: flex;
       justify-content: center;
+      align-items: center;
     }
     .count-present {
       font-family: var(--jh-font-helper-bold-font-family);
       font-weight: var(--jh-font-helper-bold-font-weight);
       font-size: var(--jh-font-helper-bold-font-size);
       line-height: var(--jh-font-helper-bold-line-height);
+      font-variant-numeric: tabular-nums;
       height: var(--jh-dimension-400);
+      min-width: var(--jh-dimension-400);
       padding: var(--jh-dimension-0) var(--jh-dimension-100);
       width: auto;
     }

--- a/packages/jh-elements/components/badge/badge.mdx
+++ b/packages/jh-elements/components/badge/badge.mdx
@@ -36,6 +36,9 @@ To use `<jh-badge>`:
 - When the `max-count` is set and surpassed by the `count`, the `max-count` will render with an appended `+` character as such: `max-count+`
 - Authors can omit the `count` property to render a dot-only badge in cases where `count` does not need to be displayed. 
 
+## Placement
+
+Place the badge at the top-right of the element it relates to, overlapping the edge. Badge does not position itself — authors are responsible for placement.
 
 ## Accessibility
 


### PR DESCRIPTION
Three CSS fixes to Badge plus a docs addition.

## `badge.js`

**`align-items: center` on `span`** — the rule set `justify-content: center` but not `align-items`, so vertical centering only worked because `line-height` happened to match `height`. Now explicit.

**`min-width: var(--jh-dimension-400)` on `.count-present`** — the base `span` sets `min-width: var(--jh-dimension-200)` (8px) and `.count-present` never overrode it, so a single-digit badge rendered ~14.9px wide against its 16px height: slightly oval instead of circular. The `.design` guidelines already document a minimum width that keeps the badge from contracting narrower than a circle; this brings the code in line.

**`box-sizing: border-box` on `span`** — not in the original scope, but the `min-width` fix does not work without it. Badge inherits the default `content-box`, so `min-width: 16px` applies to the *content* box and the 4px horizontal padding is added on top: a single-digit badge came out **24×16 — a pill, further from a circle than the 14.9px it started at**. With `border-box` the minimum measures the whole badge and a single digit is exactly 16×16. `border-box` is already the idiom in this repo (18 components use it; Badge was one of the few without).

**`font-variant-numeric: tabular-nums` on `.count-present`** — proportional numerals meant width shifted with *which* digits were shown, not just how many.

## `badge.mdx`

New `## Placement` section after "Count Behavior".

## Verification

Token, icon, analyzer, and Storybook builds all pass. Measured in a running Storybook, both themes:

| count | before | after |
|---|---|---|
| dot | 8 × 8 | 8 × 8 |
| `1` / `7` / `9` | 14.85 × 16 (oval) | **16 × 16 (circle)** |
| `11` / `77` / `99` | varied by digit | 21.7 × 16 (constant) |
| `111` / `777` | varied by digit | 28.54 × 16 (constant) |

Overview story checked at both `theme:light` and `theme:dark` — dot, `50`, and `100` (→ `99+`) all render correctly with the right tokens and centered text. No other component composes `jh-badge`, so there is no cross-component surface.

A patch changeset is included, following the repo's `[component] description` convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)