### PR TITLE
fix(divider): tokenize margins and correct inset token name in docs

### DIFF
--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -2,4 +2,4 @@
 "@jack-henry/jh-elements": patch
 ---
 
-[divider] replaces hardcoded margin values with the `--jh-dimension-400` token and corrects the inset component token name in the docs to `--jh-divider-space-inset`.
+[divider, card, and list-item] replaces the hardcoded `jh-divider` margins with the `--jh-dimension-400` token, and corrects the inset component token name in the divider, card, and list-item docs from `--jh-divider-inset-space` to `--jh-divider-space-inset`.

--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -2,4 +2,4 @@
 "@jack-henry/jh-elements": patch
 ---
 
-[divider, card, and list-item] replaces the hardcoded `jh-divider` margins with the `--jh-dimension-400` token, and corrects the inset component token name in the divider, card, and list-item docs from `--jh-divider-inset-space` to `--jh-divider-space-inset`.
+[divider, card, and list-item] replaces the hardcoded `jh-divider` margins with the `--jh-dimension-400` token, corrects the inset component token name in the divider, card, and list-item docs from `--jh-divider-inset-space` to `--jh-divider-space-inset`, and adds appearance guidance to the divider docs covering the `--jh-divider-border-style` token.

--- a/.changeset/olive-pumas-repeat.md
+++ b/.changeset/olive-pumas-repeat.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": patch
+---
+
+[divider] replaces hardcoded margin values with the `--jh-dimension-400` token and corrects the inset component token name in the docs to `--jh-divider-space-inset`.

--- a/packages/jh-elements/components/card/card.mdx
+++ b/packages/jh-elements/components/card/card.mdx
@@ -45,8 +45,8 @@ The card component makes use of required compositional dependencies.
 
 Card supports header and footer dividers to create a clearer definition before and after the card body. The left inset of the dividers can be adjusted via the following methods:
 - To adjust the left inset of each divider individually, use the `header-divider-inset` and `footer-divider-inset` attributes which supports a range from 0px to 96px with a step of 8px.
-- To set the left inset to a value outside of the divider-inset attribute range, or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-inset-space` component token instead.
-- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjuction with the `--jh-divider-inset-space` component token. Note that the divider-inset attribute will override the component token where present.
+- To set the left inset to a value outside of the divider-inset attribute range, or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-space-inset` component token instead.
+- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjuction with the `--jh-divider-space-inset` component token. Note that the divider-inset attribute will override the component token where present.
 
 ## Accessibility
 

--- a/packages/jh-elements/components/divider/divider.js
+++ b/packages/jh-elements/components/divider/divider.js
@@ -23,8 +23,8 @@ export class JhDivider extends JhElement {
           border-bottom-width: var(--jh-divider-border-width, var(--jh-border-decorative-width));
           border-bottom-style: var(--jh-divider-border-style, var(--jh-border-decorative-style));
           border-bottom-color: var(--jh-divider-color-border, var(--jh-border-decorative-color));
-          margin-top: 16px;
-          margin-bottom: 16px;
+          margin-top: var(--jh-dimension-400);
+          margin-bottom: var(--jh-dimension-400);
         }
         :host([orientation='vertical']) {
           border-bottom: none;
@@ -33,8 +33,8 @@ export class JhDivider extends JhElement {
           border-left-color: var(--jh-divider-color-border, var(--jh-border-decorative-color));
           margin-top: 0;
           margin-bottom: 0;
-          margin-left: 16px;
-          margin-right: 16px;
+          margin-left: var(--jh-dimension-400);
+          margin-right: var(--jh-dimension-400);
           height: 100%;
           width: 0px;
           align-self: stretch;

--- a/packages/jh-elements/components/divider/divider.mdx
+++ b/packages/jh-elements/components/divider/divider.mdx
@@ -33,7 +33,7 @@ Declaring a `jh-divider`:
 
 ## Inset Override for Horizontal Dividers
 
-There are thirteen left-inset options available to help align the horizontal divider with its associated content. If an inset outside of the thirteen provided options is desired, use the `--jh-divider-inset-space` component token. Note that if both the `inset` property and `--jh-divider-inset-space` component token are present, the `inset` property will take priority for that instance of the component. 
+There are thirteen left-inset options available to help align the horizontal divider with its associated content. If an inset outside of the thirteen provided options is desired, use the `--jh-divider-space-inset` component token. Note that if both the `inset` property and `--jh-divider-space-inset` component token are present, the `inset` property will take priority for that instance of the component. 
 
 ## Accessibility
 

--- a/packages/jh-elements/components/divider/divider.mdx
+++ b/packages/jh-elements/components/divider/divider.mdx
@@ -35,6 +35,12 @@ Declaring a `jh-divider`:
 
 There are thirteen left-inset options available to help align the horizontal divider with its associated content. If an inset outside of the thirteen provided options is desired, use the `--jh-divider-space-inset` component token. Note that if both the `inset` property and `--jh-divider-space-inset` component token are present, the `inset` property will take priority for that instance of the component. 
 
+## Appearance
+
+The divider renders as a solid line by default. To render a dashed divider, set the `--jh-divider-border-style` component token to `dashed`. The token accepts any CSS `border-style` value.
+
+There is no `appearance` property — the style hook is the intended way to set this in code.
+
 ## Accessibility
 
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria. The following success criteria are of concern:

--- a/packages/jh-elements/components/list-item/list-item.mdx
+++ b/packages/jh-elements/components/list-item/list-item.mdx
@@ -78,10 +78,10 @@ The left inset of the divider can be adjusted via the following methods:
 - To adjust the left inset of the divider, use the `divider-inset` attribute which supports a range from 
 0px to 96px with a step of 8px.
 - To set the left inset to a value outside of the divider-inset attribute range, 
-or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-inset-space` 
+or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-space-inset` 
 component token instead.
 - For multiple dividers with varying inset requirements, use the divider-inset attribute in conjuction with 
-the `--jh-divider-inset-space` component token. Note that the divider-inset attribute will override the 
+the `--jh-divider-space-inset` component token. Note that the divider-inset attribute will override the 
 component token where present.
 
 ## Accessibility


### PR DESCRIPTION
## Summary

Two fixes to `jh-divider`, the same docs typo in two components that consume it, and a new docs section on appearance.

**1. Tokenize the hardcoded margins** — [divider.js](packages/jh-elements/components/divider/divider.js) had four raw pixel values, the only untokenized values in the file:

- `:host([orientation='horizontal'])` — `margin-top: 16px`, `margin-bottom: 16px`
- `:host([orientation='vertical'])` — `margin-left: 16px`, `margin-right: 16px`

All four are now `var(--jh-dimension-400)`. That token is defined as `16px` in both `jh-theme-light.css` and `jh-theme-dark.css`, so this is a no-op visually.

**2. Correct the inset token name in the docs** — three `.mdx` files named the token `--jh-divider-inset-space`. The code uses `--jh-divider-space-inset`, and the JSDoc `@cssprop`, the `var()` fallback in the `margin-left` rule, and the `InsetOverride` story all agree on that spelling. The docs had it transposed, so anyone following them was setting a token that does nothing.

- [divider.mdx](packages/jh-elements/components/divider/divider.mdx)
- [card.mdx:48-49](packages/jh-elements/components/card/card.mdx)
- [list-item.mdx:81-84](packages/jh-elements/components/list-item/list-item.mdx)

`card` and `list-item` both nest a real `jh-divider` and zero out only its top/bottom margins, leaving `margin-left` free — so the token cascades through their shadow DOM and the documented behavior works, but only under the correct spelling.

**3. Add an Appearance section to the divider docs** — documents `--jh-divider-border-style` as the way to render a dashed divider, and states explicitly that there is no `appearance` property, since the style hook is the intended route in code.

## Verification

Ran the token build and Storybook, and measured computed styles in the running stories.

Margins are unchanged at both orientations in both themes:

| Root | `--jh-dimension-400` | horizontal (T R B L) | vertical (T R B L) |
| --- | --- | --- | --- |
| light | `16px` | `16px 0px 16px 0px` | `0px 16px 0px 16px` |
| dark | `16px` | `16px 0px 16px 0px` | `0px 16px 0px 16px` |

Border colors still resolve per theme (`rgb(235,235,235)` light / `rgb(62,62,62)` dark), and geometry is identical.

The documented inset behavior holds for all three components. Measured `margin-left` on the rendered `jh-divider`:

| | correct spelling | old docs spelling | inset attr + token |
| --- | --- | --- | --- |
| `jh-divider` (`InsetOverride` story) | `31px` | `0px` | `88px` |
| `jh-card` (header + footer dividers) | `31px, 31px` | `0px` | `88px` |
| `jh-list-item` | `31px` | `0px` | `88px` |

The middle column is the bug: under the spelling the docs used, the token does nothing. The right column confirms the `inset` attribute still takes priority over the token, as all three docs state, and card's two dividers both pick up a single token — the "multiple dividers at once" case card.mdx describes.

The appearance claims were checked against the component before documenting them. `--jh-divider-border-style` reaches `border-bottom-style` on horizontal and `border-left-style` on vertical, and passes arbitrary values through:

| `--jh-divider-border-style` | horizontal | vertical |
| --- | --- | --- |
| unset (default) | `solid` | `solid` |
| `dashed` | `dashed` | `dashed` |
| `dotted` | `dotted` | — |
| `double` | `double` | — |

The default resolves to `solid` via `--jh-border-decorative-style`, which is `solid` in both themes. Dashes render visibly, not just in computed style. There is no `appearance` attribute on the component — the Component API table in the rendered docs lists only `inset` and `orientation` — and `git log -S` shows neither `appearance` nor `dashed` has ever appeared in `components/divider/`.

`build-storybook` completes successfully, and the new section renders in the docs page and its table of contents.

## Note

Verifying this required running `pnpm run build:jh-tokens`, which rewrites a `Generated on` timestamp into four committed token files even with no real change. That churn is reverted here and is not part of this PR. Filed separately as #236.

🤖 Generated with [Claude Code](https://claude.com/claude-code)