### PR TITLE
[Icons] bug fix: generate-wc.js silently reported success on failure

### DIFF
--- a/.changeset/quiet-moons-report.md
+++ b/.changeset/quiet-moons-report.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-icons": patch
+---
+
+[icons] bug fix - generate-wc.js now reports generation failures and exits non-zero instead of always reporting success.

--- a/packages/jh-icons/bin/generate-wc.js
+++ b/packages/jh-icons/bin/generate-wc.js
@@ -2,13 +2,23 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-const { exec } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+const { promisify } = require('util');
+const execFile = promisify(require('child_process').execFile);
 
 const args = process.argv.slice(2); // args[0] = sourcePath, args[1] = outputPath, args[2] = prefix
+const [sourcePath, outputPath, prefix] = args;
+
+if (!sourcePath || !outputPath || !prefix) {
+  console.error('Usage: node generate-wc.js <sourcePath> <outputPath> <prefix>');
+  process.exit(1);
+}
+
+// number of hygen processes to run at once
+const CONCURRENCY = 8;
 
 // Get all files
-const fs = require('fs');
-const sourcePath = args[0];
 const iconFiles = fs.readdirSync(sourcePath); // Array of file names
 
 // Build object that pairs the icon name and the svg code
@@ -16,7 +26,7 @@ const icons = iconFiles
   .filter(fileName => fileName.includes('.svg')) // ignore non .svg files
   .map(fileName => {
     return {
-      path: `${sourcePath}${fileName}`,
+      path: path.join(sourcePath, fileName),
       name: fileName.replace('.svg', ''),
     };
   })
@@ -36,13 +46,65 @@ const icons = iconFiles
       contents: clean.replace(/\r?\n|\r/g, ' '),
     };
   });
- 
-  // For each icon, call exec create the component using hygen generator
-  icons.forEach(async icon => {
-  try {
-    await exec(`hygen icon new ${icon.name} --svg '${icon.contents}' --outputPath ${args[1]} --prefix ${args[2]}`);
-    console.log(`${icon.name} created`)
-  } catch (e) {
-    console.error('error generating icon:', e);
+
+// Create the component using the hygen generator. execFile runs without a shell,
+// so the svg markup is passed through as a single argument with no quoting.
+function generate(icon) {
+  return execFile('hygen', [
+    'icon',
+    'new',
+    icon.name,
+    '--svg',
+    icon.contents,
+    '--outputPath',
+    outputPath,
+    '--prefix',
+    prefix,
+  ]);
+}
+
+// Summarize why hygen failed without echoing the full command back, which would
+// repeat the entire svg payload for every failure.
+function reason(e) {
+  const output = [e.stderr, e.stdout]
+    .map(stream => (stream || '').trim())
+    .filter(Boolean)
+    .join(' ');
+  if (output) {
+    return output.split('\n').slice(0, 3).join(' ').slice(0, 300);
   }
-});
+  return e.code ? `hygen exited with ${e.code}` : e.message.split('\n')[0];
+}
+
+// Pull from a shared queue so at most CONCURRENCY generators run at a time
+async function worker(queue, failures) {
+  for (let icon = queue.shift(); icon; icon = queue.shift()) {
+    try {
+      await generate(icon);
+      console.log(`${icon.name} created`);
+    } catch (e) {
+      failures.push(icon.name);
+      console.error(`error generating ${icon.name}: ${reason(e)}`);
+    }
+  }
+}
+
+async function main() {
+  const queue = [...icons];
+  const failures = [];
+  const workers = Array.from(
+    { length: Math.min(CONCURRENCY, queue.length) },
+    () => worker(queue, failures)
+  );
+
+  await Promise.all(workers);
+
+  console.log(`\n${icons.length - failures.length}/${icons.length} icons created`);
+
+  if (failures.length) {
+    console.error(`failed (${failures.length}): ${failures.join(', ')}`);
+    process.exitCode = 1;
+  }
+}
+
+main();


### PR DESCRIPTION
## Problem

`generate-wc.js` used `await exec(...)` with the callback-based `exec`, inside `forEach(async ...)`. The `await` resolved immediately with a `ChildProcess`, so the surrounding `try/catch` never caught anything. Every icon logged `created` regardless of outcome and the script always exited `0`.

A regen that produced **zero files** was indistinguishable from a successful one. Reproduced against the old script — three "created" lines, exit 0, nothing written:

```
box created
bug created
heart created
>>> OLD exit=0
>>> files actually produced: 0
```

This is not an Icon problem. It affects every regen of the 389 components in `icons-wc/`, and every future one.

## This has already caused damage

`icon-robot-sparkles.js` carries a stale class name:

```
icon-robot-sparkles.js: JhIconRobotSparkle != JhIconRobotSparkles
```

That is the `.classify()` singularization bug fixed in [#225](https://github.com/Banno/jack-henry-design-system/pull/225). #225 regenerated 33 files, but this icon was added on 2026-07-23 — roughly three weeks *before* #225 merged on 2026-08-17 — so it should have been in that regen and wasn't. `icon-sparkles.js`, hit by the same singularization, *was* fixed.

**#225's regen was partial — 33 of 34 affected files — and nothing reported it.** That is precisely the failure mode this PR closes.

Impact of the stale name is low: the class is a default export, so consumers never reference it by name, and the custom element tag `jh-icon-robot-sparkles` is correct. It will be corrected as a side effect of the upcoming regen, which is called out explicitly in [#240](https://github.com/Banno/jack-henry-design-system/pull/240)'s verification gates so a reviewer doesn't read it as a partial-regen signal.

## Changes

- **`execFile` promisified** in place of callback `exec` — failures are catchable
- **Bounded worker pool** replacing `forEach(async ...)`, which spawned all 389 hygen processes at once with nothing awaiting them
- **`process.exitCode = 1` on any failure**, plus a `created/total` count and the list of failed icons
- **Compact failure reason** — Node's default error echoes the whole command, which meant repeating the entire SVG payload once per failure (unreadable at 389)
- **Usage guard** for missing arguments
- **`path.join`** for the source path, which previously required a trailing slash on `sourcePath` to work at all

`execFile` runs without a shell, so the SVG markup passes through as a single argv entry with no quoting.

## Verification

| scenario | before | after |
|---|---|---|
| hygen exits non-zero (no `_templates`) | 3× "created", **exit 0**, 0 files written | names each failure with hygen's actual error, `0/3 icons created`, **exit 1** |
| hygen unresolvable (ENOENT) | — | `hygen exited with ENOENT`, **exit 1** |
| missing arguments | reads `undefined` | usage message, **exit 1** |
| success path | — | `3/3 icons created`, **exit 0** |

**Output is unchanged.** Generated `icon-heart.js`, `icon-bug.js`, and `icon-box.js` and diffed against the checked-in files — byte-identical. Dropping the shell altered nothing about the payload.

## Class-name check

The styles-block hash used elsewhere covers `static get styles()` → `render()`. Class names sit **outside** that range, which is why the stale name above went unnoticed. This check covers it, and needs no dependencies:

```bash
node -e "
const fs = require('fs'), dir = 'packages/jh-icons/icons-wc';
const camel = n => n.split('-').map(p => p.charAt(0).toUpperCase() + p.slice(1)).join('');
let bad = 0;
for (const f of fs.readdirSync(dir).filter(f => f.endsWith('.js'))) {
  const name = f.replace(/^icon-/, '').replace(/\.js\$/, '');
  const expected = 'JhIcon' + camel(name);
  const actual = (fs.readFileSync(dir + '/' + f, 'utf8').match(/export default class (\w+)/) || [])[1];
  if (actual !== expected) { console.log(f + ': ' + actual + ' != ' + expected); bad++; }
}
console.log(bad === 0 ? 'OK: all class names match' : bad + ' mismatch(es)');
"
```

Currently prints the one known mismatch. After the regen it should print `OK: all class names match`.

## Context

First of four PRs from an Icon component review. This one is deliberately standalone and touches no component code — it needs to land before the icon regen so that regen's verification gates mean anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)