### PR TITLE
[Icon] docs: correct size values and rewrite accessibility guidance

### DIFF
--- a/.changeset/olive-pianos-shave.md
+++ b/.changeset/olive-pianos-shave.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": patch
+---
+
+[icon] docs - corrects the documented size attribute values in the style hook descriptions, adds size and style hook documentation, and rewrites the accessibility guidance around decorative vs. meaningful icons.

--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -7,12 +7,12 @@ import { JhElement } from '../element/element.js';
 
 /**
  * @cssprop --jh-icon-color-fill - The icon color. Defaults to `--jh-color-content-secondary-enabled`.
- * @cssprop --jh-icon-size-extra-small - The icon size when `size="extra-small"`. Defaults to `--jh-dimension-400`.
+ * @cssprop --jh-icon-size-extra-small - The icon size when `size="x-small"`. Defaults to `--jh-dimension-400`.
  * @cssprop --jh-icon-size-small - The icon size when `size="small"`. Defaults to `--jh-dimension-500`.
  * @cssprop --jh-icon-size-medium - The icon size when `size="medium"`. Defaults to `--jh-dimension-600`.
  * @cssprop --jh-icon-size-large - The icon size when `size="large"`. Defaults to `--jh-dimension-900`.
- * @cssprop --jh-icon-size-extra-large - The icon size when `size="extra-large"`. Defaults to `--jh-dimension-1400`.
- * @cssprop --jh-icon-size-extra-extra-large - The icon size when `size="extra-extra-large"`. Defaults to `--jh-dimension-2100`.
+ * @cssprop --jh-icon-size-extra-large - The icon size when `size="x-large"`. Defaults to `--jh-dimension-1400`.
+ * @cssprop --jh-icon-size-extra-extra-large - The icon size when `size="xx-large"`. Defaults to `--jh-dimension-2100`.
  * @slot default - Use to insert the icon SVG content.
  * @customElement jh-icon
  */

--- a/packages/jh-elements/components/icon/icon.mdx
+++ b/packages/jh-elements/components/icon/icon.mdx
@@ -30,7 +30,7 @@ Import the `<jh-icon>` component:
 import '@jack-henry/jh-elements/components/icon/icon.js';
 ```
 
-To use jh-icon, slot your own SVG markdown in the component's default slot:
+To use jh-icon, slot your own SVG markup in the component's default slot:
 
 ```html
 <jh-icon size="large">
@@ -41,6 +41,43 @@ To use jh-icon, slot your own SVG markdown in the component's default slot:
 </jh-icon>
 ```
 
+## Sizes
+
+The `size` attribute accepts six values. The default is `medium`.
+
+Each value is paired below with the style hook that overrides it and the token that hook falls back to.
+
+- `x-small` — `--jh-icon-size-extra-small`, defaults to `--jh-dimension-400`
+- `small` — `--jh-icon-size-small`, defaults to `--jh-dimension-500`
+- `medium` — `--jh-icon-size-medium`, defaults to `--jh-dimension-600`
+- `large` — `--jh-icon-size-large`, defaults to `--jh-dimension-900`
+- `x-large` — `--jh-icon-size-extra-large`, defaults to `--jh-dimension-1400`
+- `xx-large` — `--jh-icon-size-extra-extra-large`, defaults to `--jh-dimension-2100`
+
+Note that the attribute values are abbreviated (`x-small`) while the style hook names are spelled out
+(`extra-small`).
+
+## Style hooks
+
+Any or all of the icon sizes can be redefined within a given context by overriding the relevant style hook:
+
+```css
+jh-icon {
+  --jh-icon-size-medium: var(--jh-dimension-400);
+}
+```
+
+Icon color is set with `--jh-icon-color-fill`, which defaults to `--jh-color-content-secondary-enabled`:
+
+```css
+jh-icon {
+  --jh-icon-color-fill: var(--jh-color-content-brand-enabled);
+}
+```
+
+The fill is inherited by the slotted SVG, so slotted markup should not set its own `fill`. The component does
+not set `stroke`, so icons drawn with strokes rather than fills will not pick up the icon color.
+
 ## Accessibility
 
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria. The following success criteria are of concern:
@@ -48,28 +85,55 @@ This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success cr
 - [WCAG 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content): All non-text content that is presented to the user has 
 a text alternative that serves the equivalent purpose.
 
+### Decorative or meaningful
+
+Every icon is one of two things, and the required outcome differs:
+
+- **Decorative** — the icon repeats adjacent text or is purely ornamental. It must be ignored by assistive
+technology so that the same information is not announced twice.
+- **Meaningful** — the icon is the only thing conveying a piece of information. It must be exposed to assistive
+technology and carry an accessible name that describes what it conveys, not what it depicts.
+
+The component defaults to decorative.
+
 ### What we provide
 
-The icon component has the following implicit accessibility features, both of which can be overriden by the author. 
+The icon component sets the following defaults, both of which can be overridden by the author.
 
 - `role="graphics-symbol"`
 - `aria-hidden="true"`
 
+These are applied through `ElementInternals` rather than as markup, so they are present in the accessibility
+tree but will not appear as attributes in the DOM. DOM-based auditing tools may not report them.
+
+### Decorative icons
+
+No action is needed. The component is hidden from assistive technology by default.
+
+### Meaningful icons
+
+A meaningful icon needs both an accessible name and exposure to assistive technology. Setting `aria-label`
+on its own is not enough — while the element is still `aria-hidden="true"`, the label is never announced.
+Set both to satisfy [WCAG 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content):
+
+```html
+<jh-icon aria-hidden="false" aria-label="Verified">
+  <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24">
+    <path d="..."/>
+  </svg>
+</jh-icon>
+```
+
 ### Author guidance
 
-All accessibility considerations should be addressed on the jh-icon element itself and not within the slotted SVG markdown.
-Slotted SVGs should not include the `<title>` or `<desc>` elements to ensure consistency in both experience and behavior with 
-assistive technology. There are number of issues an author should consider when using the jh-icon component.
+All accessibility considerations should be addressed on the jh-icon element itself and not within the slotted
+SVG markup. Slotted SVGs should not include the `<title>` or `<desc>` elements, to ensure consistency in both
+experience and behavior with assistive technology.
 
 - If an icon must be interactive, consider using the icon only variant of our [button](/docs/components-button--docs) component or an `<a>` 
 tag wrapper instead. If icon level interactivity is necessary, set `tabindex="0"` on the `<jh-icon>` element.
-- Decorative icons, those that are paired with text or are purely for decoration, should be ignore by assistive technology. 
-By default the icon component is hidden from assisitive technology. Should interactivity be necessary, set `aria-hidden="false"` 
-to avoid anomalous behavior.
-- Note that setting a tabindex on the jh-icon while `aria-hidden="true"`, will result in assistive technology honoring browser 
+- Note that setting a tabindex on the jh-icon while `aria-hidden="true"` will result in assistive technology honoring browser 
 focus and announcing the icon.
-- To satisfy [WCAG 1.1.1 Non-text Content](https://www.w3.org/TR/WCAG22/#non-text-content), use an aria-label attribute when 
-no supporting text for the icon is present.
 
 ## Component API
 

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -1359,7 +1359,7 @@
         },
         {
           "name": "--jh-icon-size-extra-small",
-          "description": "The icon size when `size=\"extra-small\"`. Defaults to `--jh-dimension-400`."
+          "description": "The icon size when `size=\"x-small\"`. Defaults to `--jh-dimension-400`."
         },
         {
           "name": "--jh-icon-size-small",
@@ -1375,11 +1375,11 @@
         },
         {
           "name": "--jh-icon-size-extra-large",
-          "description": "The icon size when `size=\"extra-large\"`. Defaults to `--jh-dimension-1400`."
+          "description": "The icon size when `size=\"x-large\"`. Defaults to `--jh-dimension-1400`."
         },
         {
           "name": "--jh-icon-size-extra-extra-large",
-          "description": "The icon size when `size=\"extra-extra-large\"`. Defaults to `--jh-dimension-2100`."
+          "description": "The icon size when `size=\"xx-large\"`. Defaults to `--jh-dimension-2100`."
         }
       ]
     },


### PR DESCRIPTION
Documentation only. No behavior change — but the first item below documented a real, reproducible rendering bug.

## Two things were wrong

**1. The documented size values don't exist.** The `@cssprop` descriptions named `size="extra-small"`, `size="extra-large"`, and `size="extra-extra-large"`. The CSS matches `x-small`, `x-large`, and `xx-large`. `small` / `medium` / `large` were correct.

This isn't just a source comment. The descriptions flow through `custom-elements.json` into the **Component API table on the docs site**, so this is what we actively told consumers to write.

**And following it produced a broken icon.** An unmatched `size` leaves `--icon-size` undefined, `width`/`height` fall back to `auto`, and the slotted SVG renders at its default replaced-element size — measured at **300 × 304px** instead of 24 × 24px:

| `size` | rendered |
|---|---|
| `medium` | 24 × 24 |
| `extra-large` (from our API table) | **300 × 304** |

So a consumer who copied `extra-large` out of our own documentation got an icon twelve times too large, with nothing to indicate why. [#240](https://github.com/Banno/jack-henry-design-system/pull/240) fixes the underlying fallback so an unmatched value degrades to `medium`; this PR stops us from handing out the broken value in the first place. The two are independent and complementary — either alone leaves a gap, since #240 without this still leaves the docs naming attributes that silently do nothing, and this without #240 still breaks on any typo.

**2. The accessibility guidance produced a silent WCAG failure.** The section told authors to "use an aria-label attribute when no supporting text for the icon is present" to satisfy WCAG 1.1.1, but never said the component defaults to `aria-hidden="true"`. A label on an `aria-hidden` element is never announced, so following the guidance literally still fails the criterion the section exists to satisfy. The only mention of `aria-hidden="false"` was tied to *interactivity*, leaving no path for a non-interactive icon that carries meaning.

## Changes

- Fix the three `@cssprop` descriptions; regenerate `custom-elements.json`
- Add a **Sizes** section: all six values, the default, and the style hook and token behind each
- Add a **Style hooks** section: size overrides and `--jh-icon-color-fill`, plus a note that the component does not set `stroke`, so stroke-drawn icons won't pick up the icon color
- Rewrite **Accessibility** outcome-first — decorative vs. meaningful, then the mechanism for each
- Note that `role` and `aria-hidden` come from `ElementInternals`, so they're in the accessibility tree but absent from the DOM and may not be reported by DOM-based auditing tools
- Typos: "SVG markdown" → markup, "overriden", "assisitive", "should be ignore"

## Verification

- `pnpm analyze` on a clean tree produces **zero** diff, so the manifest was already in sync and the only delta here is the three intended description lines
- `pnpm build-storybook` completes successfully
- Inspected the compiled MDX chunk to confirm the new sections render as real elements

One note for future doc work: **GFM tables do not render in this Storybook's MDX pipeline.** I initially wrote the size reference as a table; it compiled to a paragraph of literal `|` characters (zero `table` elements emitted). It's a list instead. That likely explains why no other mdx in the repo uses a table — filed as [#241](https://github.com/Banno/jack-henry-design-system/issues/241).

## Context

Second of four PRs from an Icon component review. Independent of the others and safe to merge in any order, though it pairs naturally with [#240](https://github.com/Banno/jack-henry-design-system/pull/240).

🤖 Generated with [Claude Code](https://claude.com/claude-code)