### PR TITLE
[Icon] bug fix: fall back to medium when size is absent or unrecognized

### DIFF
--- a/.changeset/brave-lions-shine.md
+++ b/.changeset/brave-lions-shine.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": patch
+---
+
+[icon] bug fix - an absent or unrecognized size attribute no longer renders the icon at the SVG's intrinsic size; it now falls back to the documented medium default.

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 node_modules/
 .vscode/
 .DS_Store
+storybook-static/

--- a/packages/jh-elements/components/icon/icon.js
+++ b/packages/jh-elements/components/icon/icon.js
@@ -20,6 +20,10 @@ export class JhIcon extends JhElement {
   static get styles() {
     return css`
       :host {
+        --icon-size: var(
+          --jh-icon-size-medium,
+          var(--jh-dimension-600)
+        );
         fill: var(
           --jh-icon-color-fill,
           var(--jh-color-content-secondary-enabled)
@@ -64,7 +68,6 @@ export class JhIcon extends JhElement {
           var(--jh-dimension-2100)
         );
       }
-      svg,
       ::slotted(*) {
         width: 100%;
         height: 100%;

--- a/packages/jh-icons/_templates/icon/new/icon.ejs.t
+++ b/packages/jh-icons/_templates/icon/new/icon.ejs.t
@@ -20,6 +20,10 @@ export default class <%= h.inflection.camelize(prefix.replace(/-/gi,'_')) %>Icon
   static get styles() {
     return css`
       :host {
+        --icon-size: var(
+          --jh-icon-size-medium,
+          var(--jh-dimension-600)
+        );
         fill: var(
           --jh-icon-color-fill,
           var(--jh-color-content-secondary-enabled)


### PR DESCRIPTION
## Problem

Every size definition lives in an attribute selector, so `--icon-size` is only set when `size` matches one of the six known values. With no match, `width` and `height` fall back to `auto` and the slotted SVG renders at the default replaced-element size.

Measured in a browser: **300 × 304px**, not a collapse.

Reachable three ways:
- an unrecognized `size` value
- `removeAttribute('size')` — Lit sets the property to `null` and does not re-reflect
- the window between element upgrade and the constructor default reflecting to an attribute

It was also reachable **by following our own documentation**, which until [#239](https://github.com/Banno/jack-henry-design-system/pull/239) named `size="extra-large"`, `size="extra-small"`, and `size="extra-extra-large"` — none of which match a rule. A consumer who copied `extra-large` from the API table got a 300px icon.

## Fix

Define `--icon-size` on `:host`, so the documented `medium` default is real rather than dependent on attribute reflection.

Also drops the bare `svg` selector from `icon.js`. It can never match — `jh-icon`'s shadow root contains only a `<slot>`, so `::slotted(*)` does all the work. The generated per-icon components keep their `svg` selector, where it *is* the correct one.

The same fallback goes into the hygen template so the 389 generated components pick it up on the next regen.

## Verification

Built the component both ways and measured in a browser, in a neutral non-flex container:

| `size` | before | after |
|---|---|---|
| `medium` | 24 × 24 | 24 × 24 |
| `large` | 36 × 36 | 36 × 36 |
| `extra-large` (invalid) | **300 × 304** | 24 × 24 |
| `bogus` | **300 × 304** | 24 × 24 |
| absent | **300 × 304** | 24 × 24 |

Valid sizes are unaffected; only the unmatched cases change.

## Changeset

One changeset, **`@jack-henry/jh-elements`: patch**, covering the `icon.js` fix — that is what the bot reports.

There is deliberately **no `@jack-henry/jh-icons` changeset**, even though this PR edits `_templates/icon/new/icon.ejs.t`. `_templates` is not in that package's `files` array, so it does not ship, and no published artifact of `jh-icons` changes here. The 389 generated components under `icons-wc/` *are* published, and they don't change until the regen — so the `jh-icons` changeset belongs with the regen PR, not this one.

## Also included

`storybook-static/` added to `.gitignore` — `pnpm build-storybook` currently leaves a large untracked directory in `git status`. One line, not worth its own PR.

## Verification gates for the follow-up regen PR

The regen of all 389 generated components depends on this PR and [#238](https://github.com/Banno/jack-henry-design-system/pull/238). Its diff should be checked against three gates:

**1. Uniform styles block across all 389 files** — expect a single hash with a count of `389`:

```bash
cd packages/jh-icons/icons-wc && for f in *.js; do sed -n '/static get styles()/,/render()/p' "$f" | shasum | cut -d' ' -f1; done | sort | uniq -c | sort -rn
```

**2. That hash matches the template**, to catch a regen run from a stale template:

```bash
sed -n '/static get styles()/,/render()/p' packages/jh-icons/_templates/icon/new/icon.ejs.t | shasum | cut -d' ' -f1
```

> **Note: once this PR merges, gate 2 fails by design until the regen lands.** This PR changes the template but not the generated files, so the template hash and the checked-in hash diverge on purpose. That divergence *is* the outstanding work, and it closes when the regen merges. Gate 2 is meaningful as a check on the regen's own diff — it should pass there — not on `next` in the window between the two merges. Gate 1 still holds throughout: the 389 files stay uniform with each other the whole time, they're just uniformly one revision behind.

**3. Per-file diff shape: a 4-line insertion, nothing else.**

Verified against rendered output rather than inferred from the template diff — generated `icon-heart.js`, `icon-bug.js`, and `icon-box.js` from the updated template on this branch and diffed each against its checked-in version. All three: **+4 / −0, one hunk**. EJS interpolation does not alter the shape.

```
@@ -12,6 +12,10 @@
   static get styles() {
     return css`
       :host {
+        --icon-size: var(
+          --jh-icon-size-medium,
+          var(--jh-dimension-600)
+        );
         fill: var(
```

### Expected exception — one file, named

`icon-robot-sparkles.js` will show **two** changes: the 4-line insertion **plus** a class-name correction.

```
-export default class JhIconRobotSparkle extends LitElement {
+export default class JhIconRobotSparkles extends LitElement {
```

This is expected and is **not** a partial-regen signal. That file carries a stale singularized class name from the `.classify()` bug fixed in [#225](https://github.com/Banno/jack-henry-design-system/pull/225); it was added on 2026-07-23, before #225 merged on 2026-08-17, and was missed by that PR's regen. The regen corrects it as a side effect. Impact is nil — the class is a default export, so consumers never reference it by name, and the tag `jh-icon-robot-sparkles` is already correct.

So the expected diff shape is: **388 files with the 4-line insertion only, and `icon-robot-sparkles.js` with the insertion plus the class-name line.** Any other file showing a second changed line, or any file showing none, is a defect.

[#238](https://github.com/Banno/jack-henry-design-system/pull/238) carries a dependency-free class-name check to run alongside the hash gates — the two cover different regions of the file.

## Context

Third of four PRs from an Icon component review. Independent of [#238](https://github.com/Banno/jack-henry-design-system/pull/238) and [#239](https://github.com/Banno/jack-henry-design-system/pull/239); the regen depends on this one and #238.