### PR TITLE
docs: rewrite About page, fix docs typos and stale links

### DIFF
--- a/packages/jh-elements/components/card/card.mdx
+++ b/packages/jh-elements/components/card/card.mdx
@@ -46,7 +46,7 @@ The card component makes use of required compositional dependencies.
 Card supports header and footer dividers to create a clearer definition before and after the card body. The left inset of the dividers can be adjusted via the following methods:
 - To adjust the left inset of each divider individually, use the `header-divider-inset` and `footer-divider-inset` attributes which supports a range from 0px to 96px with a step of 8px.
 - To set the left inset to a value outside of the divider-inset attribute range, or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-inset-space` component token instead.
-- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjuction with the `--jh-divider-inset-space` component token. Note that the divider-inset attribute will override the component token where present.
+- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjunction with the `--jh-divider-inset-space` component token. Note that the divider-inset attribute will override the component token where present.
 
 ## Accessibility
 

--- a/packages/jh-elements/components/checkbox-group/checkbox-group.mdx
+++ b/packages/jh-elements/components/checkbox-group/checkbox-group.mdx
@@ -94,7 +94,7 @@ adequate spacing between checkboxes is provided to ensure the input target size 
 
 ### Author Guidance
 
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), 
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), 
 when using the `required` property and `show-indicator` attribute, include instructions at the top of 
 the form to explain required checkbox groups are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) 

--- a/packages/jh-elements/components/icon/icon.mdx
+++ b/packages/jh-elements/components/icon/icon.mdx
@@ -50,7 +50,7 @@ a text alternative that serves the equivalent purpose.
 
 ### What we provide
 
-The icon component has the following implicit accessibility features, both of which can be overriden by the author. 
+The icon component has the following implicit accessibility features, both of which can be overridden by the author. 
 
 - `role="graphics-symbol"`
 - `aria-hidden="true"`
@@ -64,7 +64,7 @@ assistive technology. There are number of issues an author should consider when 
 - If an icon must be interactive, consider using the icon only variant of our [button](/docs/components-button--docs) component or an `<a>` 
 tag wrapper instead. If icon level interactivity is necessary, set `tabindex="0"` on the `<jh-icon>` element.
 - Decorative icons, those that are paired with text or are purely for decoration, should be ignore by assistive technology. 
-By default the icon component is hidden from assisitive technology. Should interactivity be necessary, set `aria-hidden="false"` 
+By default the icon component is hidden from assistive technology. Should interactivity be necessary, set `aria-hidden="false"` 
 to avoid anomalous behavior.
 - Note that setting a tabindex on the jh-icon while `aria-hidden="true"`, will result in assistive technology honoring browser 
 focus and announcing the icon.

--- a/packages/jh-elements/components/input-email/input-email.mdx
+++ b/packages/jh-elements/components/input-email/input-email.mdx
@@ -73,7 +73,7 @@ The component provides the same accessibility support as `jh-input`.
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input-password/input-password.mdx
+++ b/packages/jh-elements/components/input-password/input-password.mdx
@@ -86,7 +86,7 @@ In addition to the accessibility features provided by `jh-input`, `jh-input-pass
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input-search/input-search.mdx
+++ b/packages/jh-elements/components/input-search/input-search.mdx
@@ -78,7 +78,7 @@ The component provides the same accessibility support as `jh-input`.
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input-telephone/input-telephone.mdx
+++ b/packages/jh-elements/components/input-telephone/input-telephone.mdx
@@ -73,7 +73,7 @@ The component provides the same accessibility support as `jh-input`.
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input-textarea/input-textarea.mdx
+++ b/packages/jh-elements/components/input-textarea/input-textarea.mdx
@@ -77,13 +77,13 @@ The following success criteria are of concern:
 - To satisfy [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) and [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value), any `label`, `helper-text`, and `error-text` are associated with the input control by default.
 - To satisfy [WCAG 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html), input-textarea can be resized without assistive technology up to 200 percent without loss of content or functionality.
 - To satisfy [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html) and [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html), interactive elements include focus styles.
-- To satisfy [WCAG 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html), inpu-textarea replicates native textarea keyboard support. 
+- To satisfy [WCAG 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html), input-textarea replicates native textarea keyboard support. 
 - To satisfy [WCAG 2.5.8 Target Size (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/target-size-minimum.html), the target size for the input field is at least 24 by 24 pixels so users can easily activate the control.
 
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input-url/input-url.mdx
+++ b/packages/jh-elements/components/input-url/input-url.mdx
@@ -73,7 +73,7 @@ The component provides the same accessibility support as `jh-input`.
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/input/input.mdx
+++ b/packages/jh-elements/components/input/input.mdx
@@ -146,7 +146,7 @@ The following success criteria are of concern:
 ### Author Guidance
 
 - To satisfy [WCAG 1.3.5 Identify Input Purpose](https://www.w3.org/WAI/WCAG22/Understanding/identify-input-purpose.html), use the `autocomplete` property to allow automated assistance in providing an input value.
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), when using the `required` property and `show-indicator` attribute, include instructions at the top of the form to explain required inputs are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) and [WCAG 3.3.2 Labels or Instructions](https://www.w3.org/WAI/WCAG22/Understanding/labels-or-instructions.html), ensure the `label` property or the `accessible-label` attribute are descriptive.
 - To satisfy [WCAG 3.3.1 Error Identification](https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html), set the `invalid` attribute to generate an `aria-invalid` attribute on input to indicate an error. Utilize the `error-text` attribute to provide feedback on a failed value.
 - To satisfy [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/error-suggestion.html), use the `error-text` attribute to provide a suggestion to correct the input error when appropriate.

--- a/packages/jh-elements/components/list-item/list-item.mdx
+++ b/packages/jh-elements/components/list-item/list-item.mdx
@@ -80,7 +80,7 @@ The left inset of the divider can be adjusted via the following methods:
 - To set the left inset to a value outside of the divider-inset attribute range, 
 or for multiple dividers at once, omit the divider-inset attributes and use the `--jh-divider-inset-space` 
 component token instead.
-- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjuction with 
+- For multiple dividers with varying inset requirements, use the divider-inset attribute in conjunction with 
 the `--jh-divider-inset-space` component token. Note that the divider-inset attribute will override the 
 component token where present.
 

--- a/packages/jh-elements/components/notification/notification.mdx
+++ b/packages/jh-elements/components/notification/notification.mdx
@@ -15,7 +15,7 @@ import * as stories from './notification.stories.js';
 
 <hr />
 
-The notification component displays information to the user, and supports both alerts and banner type notifications. Alert types are best suited for information that should be conveyed in response to a specific user action, while banner types are best suited for general or persistant information. 
+The notification component displays information to the user, and supports both alerts and banner type notifications. Alert types are best suited for information that should be conveyed in response to a specific user action, while banner types are best suited for general or persistent information. 
 
 ## Usage
 

--- a/packages/jh-elements/components/progress/progress.mdx
+++ b/packages/jh-elements/components/progress/progress.mdx
@@ -54,7 +54,7 @@ This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success cr
 
 - To satisfy [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html), set an `accessible-label` to generate an `aria-label` when a visible label cannot be used.
 
-- Set the `accessible-valuetext` attribute to generate an `aria-valuetext` attribute when the rendered value cannot be meaningfully represensented as a number.
+- Set the `accessible-valuetext` attribute to generate an `aria-valuetext` attribute when the rendered value cannot be meaningfully represented as a number.
 
 ## Component API
 

--- a/packages/jh-elements/components/radio-group/radio-group.mdx
+++ b/packages/jh-elements/components/radio-group/radio-group.mdx
@@ -108,7 +108,7 @@ and [WCAG 3.3.3 Error Suggestion](https://www.w3.org/WAI/WCAG22/Understanding/er
 
 ### Author Guidance
 
-- To satisy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), 
+- To satisfy [WCAG 1.4.1 Use of Color](https://www.w3.org/WAI/WCAG22/Understanding/use-of-color.html), 
 when using the `required` property and `show-indicator` attribute, include instructions at the top of 
 the form to explain required radio groups are marked with a red asterisk.
 - To satisfy [WCAG 2.4.6 Headings and Labels](https://www.w3.org/WAI/WCAG22/Understanding/headings-and-labels.html) 

--- a/packages/jh-elements/components/tag-group/tag-group.mdx
+++ b/packages/jh-elements/components/tag-group/tag-group.mdx
@@ -68,7 +68,7 @@ The following success criteria are of concern:
 dynamically from the tag group, authors should ensure that the tag group is set up as a live region:
     - setting `aria-live` to `polite`is preferred, so announcements will not disrupt the user's work flow.
     - setting `aria-relevant` to `additions removals` will announce both tag additions and removals. If it is omitted, only additions will be announced.
-    - setting `aria-atomic` to `true` is only needed if the whole live-region needs to be announced. If it is omitted, only new addtions and removals will be announced.
+    - setting `aria-atomic` to `true` is only needed if the whole live-region needs to be announced. If it is omitted, only new additions and removals will be announced.
 - To ensure that tag groups are announced correctly by screen readers, authors should provide an `aria-label`.
 
 ## Component API

--- a/packages/jh-elements/components/toast-controller/toast-controller.mdx
+++ b/packages/jh-elements/components/toast-controller/toast-controller.mdx
@@ -86,14 +86,14 @@ The following success criteria are of concern:
 ### What we provide
 
 - To satisfy [WCAG 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html),
-the `role='status'` property is set by default in order to allow changes to be announced via screen readers without receiving focus or interupting the user flow. If the toast(s) added to the toast controller contain important, time-sensitive information, see the author guidance section below. 
+the `role='status'` property is set by default in order to allow changes to be announced via screen readers without receiving focus or interrupting the user flow. If the toast(s) added to the toast controller contain important, time-sensitive information, see the author guidance section below. 
 
 ### Author Guidance
 
 - To satisfy [WCAG 2.4.11 Focus Not Obscured (Minimum)](https://www.w3.org/WAI/WCAG22/Understanding/focus-not-obscured-minimum.html), ensure that when toasts are opened, they do not completely obscure the component that has keyboard focus.
 - To satisfy [WCAG 4.1.3 Status Messages](https://www.w3.org/WAI/WCAG22/Understanding/status-messages.html) when a status message conveys a warning, rather than the success or result of an action, set `role='alert'` in order to allow changes to be announced via screen readers immediately. 
-- Both the `role='status'` and `role='alert'` have an implicit `aria-atomic` value of true. This means a screen reader will present the entire changed region when new toasts are added. Consider setting `aria-atomic='false'` on the toast controller for instances in which the entire region does not need to be announced with each incoming toast. [Visit MDN for more information on the aria-atomic attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-atomic).
-- Authors can utilize an `aria-relevant` attribute to further specify which types of changes to the live region should be announced. [Visit MDN for information on supported aria-relevant values](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant).
+- Both the `role='status'` and `role='alert'` have an implicit `aria-atomic` value of true. This means a screen reader will present the entire changed region when new toasts are added. Consider setting `aria-atomic='false'` on the toast controller for instances in which the entire region does not need to be announced with each incoming toast. [Visit MDN for more information on the aria-atomic attribute](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-atomic).
+- Authors can utilize an `aria-relevant` attribute to further specify which types of changes to the live region should be announced. [Visit MDN for information on supported aria-relevant values](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-relevant).
 - Authors should consider placing the `<jh-toast-controller>` either at the beginning or end of the page as to not disturb user flow for those dependent on keyboard navigation. 
 
 ## Component API

--- a/packages/jh-elements/components/toast/toast.mdx
+++ b/packages/jh-elements/components/toast/toast.mdx
@@ -55,7 +55,7 @@ The following roles should be considered for the live-region depending on the pu
 - `role=”alert”` may be appropriate when the toast includes important, and usually time-sensitive, information. Elements with the role of alert have an implicit aria-live value of assertive, and an implicit aria-atomic value of true.
 - `role=”status”` may be appropriate when the toast contains advisory information for the user but is not important enough to justify an alert. Elements with the role status have an implicit aria-live value of polite and an implicit aria-atomic value of true.
 
-Additionally, authors can specify which types of changes to the live region should be announced via the aria-relevant attribute. Visit [MDN for information on supported aria-relevant values](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Attributes/aria-relevant).
+Additionally, authors can specify which types of changes to the live region should be announced via the aria-relevant attribute. Visit [MDN for information on supported aria-relevant values](https://developer.mozilla.org/en-US/docs/Web/Accessibility/ARIA/Reference/Attributes/aria-relevant).
 
 ## Action Slot Guidance
 

--- a/packages/jh-elements/components/tooltip/tooltip.mdx
+++ b/packages/jh-elements/components/tooltip/tooltip.mdx
@@ -69,7 +69,7 @@ the tooltip's `role` is set to `tooltip`.
 - To satisfy [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html), the `aria-describedby` property is automatically set on the originating element and the `id` property 
 is automatically set on the tooltip to establish the relationship between the tooltip and the originating element.
 - To satisfy [WCAG 1.4.13 Content on Hover or Focus](https://www.w3.org/WAI/WCAG22/Understanding/content-on-hover-or-focus)
-  - The tooltip is displayed on hover or focus on the originiating element.
+  - The tooltip is displayed on hover or focus on the originating element.
   - The tooltip itself is hoverable and will close once the mouse leaves both the tooltip and originating element.
   - Keyboard support is provided to dismiss the tooltip using the `Escape` or `Tab` keys when the element has been focused 
 with the tab key.

--- a/packages/jh-elements/docs/about-jh/about.mdx
+++ b/packages/jh-elements/docs/about-jh/about.mdx
@@ -8,88 +8,72 @@ import { Meta } from '@storybook/addon-docs/blocks';
 
 <Meta title="Welcome/About JH" />
 
-# About JH
+# About Forge
 
-The Forge Design System is a collection of reusable components, guided by clear visual and user experience
-standards that help teams build great products. The design system is informed by internal Jack Henry patterns and extensive
-UX research. We've solved many of the common UX problems and baked in accessibilty so that you can focus on your product's 
-unique needs. It's a living system constantly growing, with frequent releases that include new features and improvements. The Forge
-Design System will help your product teams by:
+Forge is the design system behind every product Jack Henry ships, serving designers and engineers across web, iOS, and Android.
+This site documents the web component library. For foundations, content guidelines, and design documentation, see
+[jackhenry.design](https://jackhenry.design).
 
-- Establishing brand and UX consistency, ensuring all products are aligned to a set of standards.
-- Reduce time to market through design and code reuse. No need to build from scratch.
-- Solving common uses cases, enabling teams to focus on complex problems unique to your product.
-- Creating a foundation for accessibility and internationalization.
+## How it's built
 
-## Principles
+### Web standards, not framework bindings
 
-### Framework Agnostic
+Components are built on native web component technologies. You're not locked into a framework, and they work inside whatever
+stack you're already running.
 
-We have the modern web in mind. Our components are built on native web component technologies and standards that are framework agnostic. You’re not 
-locked into a particular framework out of the box and our components will work comfortably within the tech stack of your choice if needed.
+### Accessible by default
 
-### Modular
+Components are built against W3C WCAG standards. The common accessibility problems are handled at the component level, so your
+team can focus on what's specific to your product.
 
-All our components are designed and engineered to be reusable and work seamlessly together to help you build great applications as quickly as possible 
-with as little code as possible.
+### Themeable through tokens
 
-### Accessible
+A design token foundation with theming hooks at the component level gives you precise control over look and feel, including
+white-label theming across products.
 
-We've baked in accessibilty support around every corner and aligned with W3C's WCAG standards. Each component is thoughtfully crafted to take into account 
-the needs of all users. We've solved common accessibilty issues for you so that you can be confident our components work everywhere and for everyone.
+### Modular and lightweight
 
-### Consistency
+Components are designed to compose. We manage dependencies carefully and work as close to the browser as possible, which keeps
+bundle size down without cutting functionality.
 
-Our components are built with a foundation of robust design tokens that enable white label theming of your products. We've unlocked theming hooks at the
-component level enabling precise control over your application's look and feel, helping you achieve a consistent user experience throughout your products.
+### Built to fit your process
 
-### Scalable
-
-Our design system is designed to be scalable, ensuring that it can grow and adapt to meet the evolving needs of our community. To achieve this, we
-prioritized extensibility and flexibility to ensure our components can be extended for your use cases and adapted to your brand. The Forge Design System 
-has community in mind. Our system is constantly evolving with frequent releases that include new features, bug fixes, and quality of life improvements 
-driven by community feedback.
-
-### Performant
-
-We prioritize performance by minimizing code bloat, carefully managing dependencies, and ensuring that our components are lightweight 
-and optimized for speed. We achieve this by working as closely to the browser as possible, using modern web technologies to improve performance 
-without sacrificing functionality.
-
-### DX Driven
-
-Designer and Developer experience are a core concern and we've invested heavily to ensure our components stay out of your way. With a declarative and intuitive 
-API and extensive documentation at your disposal, our components will fit right into your development process without the need to learn a new system, letting 
-you focus on solving high impact problems unique to your domain.
+A declarative, predictable API and thorough documentation mean Forge drops into your workflow rather than asking you to learn a
+new system.
 
 ## Browser support
-All components are tested in the latest 2 versions of Chrome, Firefox, and Safari.
 
 <table>
   <thead>
     <tr>
       <th>Browser</th>
-      <th>Supported Versions</th>
+      <th>Supported versions</th>
     </tr>
   </thead>
   <tbody>
     <tr>
       <td>Chrome</td>
-      <td>Latest 2 versions</td>
+      <td>Latest 2</td>
     </tr>
     <tr>
       <td>Firefox</td>
-      <td>Latest 2 versions</td>
+      <td>Latest 2</td>
     </tr>
     <tr>
       <td>Safari</td>
-      <td>Latest 2 versions</td>
+      <td>Latest 2</td>
     </tr>
   </tbody>
 </table>
 
+## Support and contribution
+
+Forge is maintained by Jack Henry's design system team. To report a bug or request a component,
+[open an issue](https://github.com/Banno/jack-henry-design-system/issues). If you want to contribute code, start with
+[Contributing](?path=/docs/welcome-contributing--docs).
+
 ## Licensing
 {/* REUSE-IgnoreStart */}
-Our design system, including all components, design tokens, and source code, is licensed under the **Apache License, Version 2.0**. This project adheres to the REUSE specification, with license information declared using the `SPDX-License-Identifier: Apache-2.0` tag in each source file.
+Forge — components, design tokens, and source — is licensed under the **Apache License, Version 2.0**. The project follows the REUSE specification, with license information declared via `SPDX-License-Identifier: Apache-2.0` in each source file.
 {/* REUSE-IgnoreEnd */}
-Please see the complete [license file](https://github.com/Banno/jack-henry-design-system/blob/release/v2/LICENSE) for full legal details.
+See the [full license](https://github.com/Banno/jack-henry-design-system/blob/release/v2/LICENSE) for legal details.

--- a/packages/jh-elements/docs/getting-started/typography.mdx
+++ b/packages/jh-elements/docs/getting-started/typography.mdx
@@ -30,7 +30,7 @@ If the fonts are hosted on  a different domain than the application, there may b
 You will need to add `Access-Control-Allow-Origin` header to the response from your server. 
 
 If you are using a bundler like Webpack5 or Vite, make sure to have the appropriate 
-[Loaders](https://webpack.js.org/guides/asset-management/#loading-css) and Asset management setup for [Webpack 5](https://webpack.js.org/guides/asset-management/#loading-fonts) or [Vite](https://vitejs.dev/guide/assets.html#static-asset-handling), 
+[Loaders](https://webpack.js.org/guides/asset-management/#loading-css) and Asset management setup for [Webpack 5](https://webpack.js.org/guides/asset-management/#loading-fonts) or [Vite](https://vite.dev/guide/assets.html#static-asset-handling), 
 to ensure that the bundler can handle the css and font imports. 
 
 To import the fonts.css file into the `<head>` of your main HTML page, use a link: 

--- a/packages/jh-elements/docs/getting-started/usage.mdx
+++ b/packages/jh-elements/docs/getting-started/usage.mdx
@@ -11,9 +11,9 @@ import { Meta } from '@storybook/addon-docs/blocks';
 # Usage
 
 Each web component includes a custom element and an associated JavaScript class that defines its public interface, behaviors, styles, and
-any implicit features such as accessibilty. We ensure that our components follow as closely as possible any behaviors or conventions
+any implicit features such as accessibility. We ensure that our components follow as closely as possible any behaviors or conventions
 defined in the HTML standard or are generally considered expected by engineers, with few exceptions.
-All components and their public API are thouroughly documented. Please review in depth before using each component. 
+All components and their public API are thoroughly documented. Please review in depth before using each component. 
 
 ## Using components
 
@@ -75,7 +75,7 @@ For more information on working with styling hooks, please reference the [design
 
 The Roboto Flex variable font is our primary font. We strongly encourage self-hosting fonts rather than relying on google fonts' CDN. 
 
-The fonts and related css files are availabe for download from our [Github Repo - V2](https://github.com/Banno/design-system/tree/release/v2/assets/fonts).
+The fonts and related css files are available for download from our [Github Repo - V2](https://github.com/Banno/jack-henry-design-system/tree/release/v2/assets/fonts).
 
 See the [Typography page](/docs/getting-started-typography--docs) for more detailed instructions and options for font hosting.
 

--- a/packages/jh-elements/docs/guides/datasets.mdx
+++ b/packages/jh-elements/docs/guides/datasets.mdx
@@ -23,7 +23,7 @@ Additional datasets may be added in the future and can be requested by submittin
 ## Using the Datasets Package
 
 The datasets package is not a dependency of the `jh-elements` package, so you will need to install it separately and import the datasets you want to use.
-To use the datasets, import the dataset you want to use from the `datasets` directory and pass it to the compatible component thorugh the `.options` property:
+To use the datasets, import the dataset you want to use from the `datasets` directory and pass it to the compatible component through the `.options` property:
 
 ```javascript
 import { US_STATES_FLAT } from '@jack-henry/jh-datasets/datasets/us-states-flat.js';

--- a/packages/jh-elements/docs/iconography/iconography.mdx
+++ b/packages/jh-elements/docs/iconography/iconography.mdx
@@ -33,7 +33,7 @@ your own support for our design tokens if you want to ensure consistency.
 
 Using our web component icons is the preferred path. Using component based icons provide the following benefits:
 
-- Supports component driven developent and makes it easy to reuse icons throughout your app.
+- Supports component driven development and makes it easy to reuse icons throughout your app.
 - Helps ensure consistency by hooking into our design tokens.
 - Supports build processes such as tree shaking and code splitting via ES modules.
 

--- a/packages/jh-elements/docs/whats-new/jh-elements.mdx
+++ b/packages/jh-elements/docs/whats-new/jh-elements.mdx
@@ -90,7 +90,7 @@ The `jh-icon` component now supports a new `xx-large` sizing option, along with 
 
 ### jh-list-item
 
-In version 1, the text in `jh-list-item` would atuomatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
+In version 1, the text in `jh-list-item` would automatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
 This behavior was removed due to accessibility and design concerns. The text in `jh-list-item` now wraps to a new line. 
 
 We have also added styling hooks to adjust the padding and text color of the list items. For a complete list of available styling hooks, review the [list item styling hooks table](?path=/docs/components-list-item--docs#component-api).
@@ -113,7 +113,7 @@ The width of `jh-switch` has been updated to 48px from 56px(as present in V1). A
 
 ### jh-tag
 
-In version 1, the text in `jh-tag` would atuomatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
+In version 1, the text in `jh-tag` would automatically truncate at a certain width of the component. In V2 we deprecated the truncation behavior of these components. 
 This behavior was removed due to accessibility and design concerns. The text in `jh-tag` will now expand to contain the full text.
 
 ### jh-toast
@@ -155,7 +155,7 @@ A non-editable single select dropdown component that displays a list of options.
 
 ### jh-table
 
-An enhanced HTML table component, which includes sorting hooks, and all its supcomponents:
+An enhanced HTML table component, which includes sorting hooks, and all its subcomponents:
 
 - `jh-table`: the table component, which also includes caption, toolbar and pagination slots.
 - `jh-table-row`: the table row component, which contains header and data cells.

--- a/packages/jh-elements/docs/whats-new/jh-tokens.mdx
+++ b/packages/jh-elements/docs/whats-new/jh-tokens.mdx
@@ -15,7 +15,7 @@ Tokens 2.0 realigns our design tokens with the W3C Design Token Specification. T
 for defining design tokens. Adopting the DTCG token specification requires updates to our core tooling and the way we organize our data. Tokens 2.0 includes a number of improvements
 including a simplified color system, support for shadow and overlay tokens, typography updates, improved platform files, and more.
 
-Learn more about the DTCG specification [here](https://tr.designtokens.org/format/).
+Learn more about the DTCG specification [here](https://www.designtokens.org/tr/drafts/format/).
 
 ## JS-CSS Token Folder Renaming
 
@@ -39,7 +39,7 @@ In addition we have made the following changes to our color families:
 - Introduced new color families for black and white colors with alpha channels.
 - Updated the gray color family to use more neutral colors.
 - Renamed the `azure` color family to `blue`. The values for all `--jh-color-blue-x` tokens have been updated to the previous azure values in HEX8 format.
-- Removed the lime, rose, and the original blue color families to help create more disctinction between the available color families.
+- Removed the lime, rose, and the original blue color families to help create more distinction between the available color families.
 
 ### New Black and White Color Tokens
 
@@ -143,9 +143,9 @@ Our components now leverage the broken out tokens, but the shorthand typography 
 
 ### Border Tokens
 
-In v1, only the color of borders was cusomizable by authors via tokens. 
+In v1, only the color of borders was customizable by authors via tokens. 
 In v2, we introduce a new set of composite border tokens that align with the DTCG specification, which define the width, style, and color of borders individually. 
-We have named these tokens according to their usage, to make it easier for authors to idenfiy the appropriate token for their use case.
+We have named these tokens according to their usage, to make it easier for authors to identify the appropriate token for their use case.
 
 ### New Border Tokens
 

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -51,7 +51,7 @@ For detailed guidance on using Lit 3 with Webpack 4, refer to the [Lit upgrade g
 
 ### Package Changes
 
-* Fonts have moved out of `jh-tokens` to a dedicated `Assets` folder and need to be dowloaded from there to be self-hosted.
+* Fonts have moved out of `jh-tokens` to a dedicated `Assets` folder and need to be downloaded from there to be self-hosted.
 * The folder containing `esm` token files has been renamed from `js-css` to `esm`.
 
 ### Deprecated Dimension Tokens


### PR DESCRIPTION
## What It Does

Rewrites the Forge About page, and fixes spelling and link problems found while sweeping the surrounding docs.

### About page (`about.mdx`) — the part to actually review

- "Principles" becomes "How it's built," collapsing seven items into five (Framework Agnostic, Modular, Accessible, Consistency, Scalable, Performant, DX Driven → Web standards / Accessible by default / Themeable through tokens / Modular and lightweight / Built to fit your process).
- The opening paragraph re-explaining what a design system is is cut, replaced by a one-line definition plus a link out to jackhenry.design.
- New "Support and contribution" section: GitHub Issues as primary intake, Contributing as the secondary path for people writing code.
- The redundant sentence above the browser support table is gone; the table stands alone.

### Everything else

22 spelling fixes across the docs and component docs, and four stale or redirecting links updated. One of them (`usage.mdx:78`) pointed at `Banno/design-system` — the archived, internal-visibility predecessor repo, which 404s for anyone outside the org. Repointed at `jack-henry-design-system`; `assets/fonts` on `release/v2` is identical in both, so nothing else moved. The other three are the DTCG spec, the Vite asset guide, and the MDN ARIA pages that moved under `/Reference/`.

**Idea number or other reference:** n/a

## How To Test

Open **Welcome → About JH** in Storybook and read it top to bottom. The story title is unchanged, so existing links to it still resolve.

All 52 MDX files in `packages` were compile-checked with `@mdx-js/mdx` (0 failures). Every external URL in the touched docs was status-checked: no 404s remain, and no link in the docs redirects.

## Notes

- `http://www.w3.org/2000/svg` in `icon.mdx:37` is deliberately untouched. The link check flags it as a redirect, but it's the `xmlns` attribute inside a code block — an XML namespace identifier, not a link. Changing it to `https://` would break the markup.
- "Support" links to the existing Welcome/Contributing story, since no Support page exists. If that page should be retitled "Support," that's a follow-up.
- Docs-only, no changeset.