### PR TITLE
docs: fix three incorrect API names in the V2 migration guide

### DIFF
--- a/packages/jh-elements/components/tooltip/tooltip.stories.js
+++ b/packages/jh-elements/components/tooltip/tooltip.stories.js
@@ -80,21 +80,21 @@ export const Overview = {
       <div>
         <jh-tooltip position="top-start">
           <span slot="jh-tooltip-content">top-start</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="top-center">
           <span slot="jh-tooltip-content">top-center</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="top-end">
           <span slot="jh-tooltip-content">top-end</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
@@ -103,14 +103,14 @@ export const Overview = {
       <div class="overviewSides">
         <jh-tooltip position="left">
           <span slot="jh-tooltip-content">left</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="right">
           <span slot="jh-tooltip-content">right</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
@@ -119,21 +119,21 @@ export const Overview = {
       <div>
         <jh-tooltip position="bottom-start">
           <span slot="jh-tooltip-content">bottom-start</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="bottom-center">
           <span slot="jh-tooltip-content">bottom-center</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button
         ></jh-tooltip>
         <jh-tooltip position="bottom-end">
           <span slot="jh-tooltip-content">bottom-end</span>
-          <jh-button icon-position="before" accessible-label="view more"
+          <jh-button accessible-label="view more"
             ><jh-icon-ellipsis
               slot="jh-button-icon-left"
             ></jh-icon-ellipsis></jh-button

--- a/packages/jh-elements/docs/whats-new/migrating.mdx
+++ b/packages/jh-elements/docs/whats-new/migrating.mdx
@@ -387,7 +387,7 @@ import '@jack-henry/jh-elements/components/divider/divider.js';
       <td>Input Components</td>
       <td>`jh-select`</td>
       <td>`e.detail.selected`, `e.detail.selectionStart`, `e.detail.selectionEnd`</td>
-      <td>`e.detail.state.selected`, `e.detail.state.selectionStart`, `e.detail.state.selectionEnd`</td>
+      <td>`e.detail.state.selection`, `e.detail.state.selectionStart`, `e.detail.state.selectionEnd`</td>
     </tr>
     <tr>
       <td>Select</td>
@@ -397,7 +397,7 @@ import '@jack-henry/jh-elements/components/divider/divider.js';
     </tr>
     <tr>
       <td>Table Header Cell</td>
-      <td>`jh-change`</td>
+      <td>`jh-sort`</td>
       <td>`e.detail.column`, `e.detail.sorted`, `e.detail.id`</td>
       <td>`e.detail.reference.column`, `e.detail.reference.sorted`, `e.detail.reference.id`</td>
     </tr>
@@ -410,7 +410,7 @@ The `max-count` property is now set to `99` by default.
 
 ### Migrating jh-button
 #### jh-button slots
-The button component now supports left and right icon positioning via the new `jh-button-icon-left` and `jh-button-icon-right` slots. Because of this, the `jh-button-icon` slot has been deprecated. To update your code, replace all instances of `jh-button-icon` with `jh-button-left-icon` and remove any `icon-position="before"|"after"` properties.
+The button component now supports left and right icon positioning via the new `jh-button-icon-left` and `jh-button-icon-right` slots. Because of this, the `jh-button-icon` slot has been deprecated. To update your code, replace all instances of `jh-button-icon` with `jh-button-icon-left` and remove any `icon-position="before"|"after"` properties.
 
 #### jh-button sizes
 The button component now supports a new `size="x-small"` option. The existing sizes (small, medium, and large) have been downsized by 8px each. This layout change may reduce the overall height of any components that import `jh-button`, including `jh-notification`. Icons within the button are now automatically sized to `x-small` when the button is `x-small`, and `medium` for all other button sizes.


### PR DESCRIPTION
## What It Does

**Migration guide name fixes** — three names in the V1→V2 tables didn't match the codebase, all verified against source:

- `jh-select` payload key is `e.detail.state.selection`, not `.selected` (`input.js:1099-1105`)
- Table Header Cell dispatches `jh-sort`, not `jh-change` (`table-header-cell.js:68`)
- Button icon slot is `jh-button-icon-left`, not `jh-button-left-icon` — the same sentence introduced the correct name and then used the wrong one (`button.js:112`)

These fail silently for anyone following the guide: a listener that never fires, or a slot that doesn't match. The V1 "Previous Property Path" column is intentionally unchanged.

**Also** — removed 8 inert `icon-position="before"` attributes from `tooltip.stories.js`. `jh-button` has no such property, but the stories were demonstrating the exact attribute the migration guide tells consumers to remove. Repo-wide, `icon-position` now appears only in `migrating.mdx` as the deprecated name.

**Idea number or other reference:** n/a

## How To Test

- Review documentation
- Review component(s) on Storybook

**Additional Details**

- Documentation: open the "Upgrading to V2" page and check the JhElement event table (Table Header Cell row now reads `jh-sort`; `jh-select` row now reads `e.detail.state.selection`) and the `jh-button` slots paragraph.
- Storybook: the Tooltip Overview story should render identically to before — the removed attribute was inert, so this is a visual no-op.

## Notes/Dependencies

- Docs and stories only; no component source or published behavior changes, so no changeset.
- The audit covered every slot, attribute, and event name in `migrating.mdx`. These three were the only mismatches — everything else, including the deprecated names the guide says to remove, matches the codebase.
- The "Previous Property Path" column describes the V1 API and can't be checked against this tree. CSS custom properties were out of scope for this pass.