### PR TITLE
[Select] Add searchable select with docs and stories

### DIFF
--- a/.changeset/full-trees-shake.md
+++ b/.changeset/full-trees-shake.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[Select] add searchable select and update docs and stories.

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -75,8 +75,10 @@ export class JhSelect extends JhInput {
   #open = false;
   /** @type {Array} All options flattened — source of truth, rebuilt only when options change */
   #allOptions = [];
-  /** @type {Array} Currently visible/navigable options — same as #allOptions until search is added */
+  /** @type {Array} Currently visible/navigable options — filtered subset of #allOptions when searching */
   #flatOptions = [];
+  /** @type {?string} Current search query when searchable; null when not actively searching */
+  #searchTerm = null;
   /** @type {(e: Event) => void} */
   #boundDocumentClick;
   /** @type {(e: Event) => void} */
@@ -149,7 +151,7 @@ export class JhSelect extends JhInput {
           visibility: visible;
           opacity: 1;
         }
-        input::selection {
+        :host(:not([searchable])) input::selection {
           background-color: transparent;
         }
         jh-menu {
@@ -199,6 +201,10 @@ export class JhSelect extends JhInput {
       options: { type: Array, attribute: false },
       /** Prevents the dropdown menu from automatically flipping its position when there is insufficient viewport space. */
       flipDisabled: { type: Boolean, attribute: 'flip-disabled' },
+      /** Allows users to type in the input field to filter the list of options. */
+      searchable: { type: Boolean, reflect: true },
+      /** Sets the message shown in the menu when a search returns no matching options. Only applies when `searchable` is set. */
+      noResultsText: { type: String, attribute: 'no-results-text' }
     };
   }
 
@@ -210,6 +216,12 @@ export class JhSelect extends JhInput {
     this.options = [];
     /** @type {boolean} */
     this.flipDisabled = false;
+    /** Whether the options are searchable 
+     * @type {boolean}
+    */
+    this.searchable = false;
+    /** @type {string} */
+    this.noResultsText = 'No results found';
     this.addEventListener('keydown', this.#handleKeydown);
     this.#boundDocumentClick = this.#handleDocumentClick.bind(this);
     this.#boundDocumentScroll = this.#handleDocumentScroll.bind(this);
@@ -245,6 +257,7 @@ export class JhSelect extends JhInput {
       });
       this.#flatOptions = this.#allOptions;
       this.#activeIndex = null;
+      this.#searchTerm = null;
 
       // If no value is set yet, use the selected flag as the initial default
       if (this.value == null) {
@@ -320,7 +333,8 @@ export class JhSelect extends JhInput {
   }
 
   #handleOpenSelect({ keyboard = false } = {}) {
-    if (this.disabled || this.readonly || !this.#flatOptions.length) return;
+    const hasOptions = this.searchable ? this.#allOptions.length : this.#flatOptions.length;
+    if (this.disabled || this.readonly || !hasOptions) return;
     if (!this.#inputWrapper || !this.#menuContainer) return;
 
     this.#flipMenu();
@@ -341,6 +355,9 @@ export class JhSelect extends JhInput {
   #handleCloseSelect() {
     this.#open = false;
     this.#buffer = '';
+    // Revert the field to the selected value and restore the full option list
+    this.#searchTerm = null;
+    this.#applyFilter('');
     clearTimeout(this.#timer);
     if (this.#menuContainer) {
       this.#menuContainer.style.top = '';
@@ -404,16 +421,29 @@ export class JhSelect extends JhInput {
         return;
 
       case 'Enter':
-      case ' ':
         e.preventDefault();
         if (!this.#open) {
-          this.#handleOpenSelect({ keyboard: true }); 
-      } else if (this.#activeIndex !== null) {
+          this.#handleOpenSelect({ keyboard: true });
+        } else if (this.#activeIndex !== null) {
           this.#handleSelection(this.#activeIndex);
           this.#handleCloseSelect();
-      } else {
-        this.#handleCloseSelect();
-      }
+        } else {
+          this.#handleCloseSelect();
+        }
+        return;
+
+      case ' ':
+        // In searchable mode Space is a search character, not a selection key
+        if (this.searchable) return;
+        e.preventDefault();
+        if (!this.#open) {
+          this.#handleOpenSelect({ keyboard: true });
+        } else if (this.#activeIndex !== null) {
+          this.#handleSelection(this.#activeIndex);
+          this.#handleCloseSelect();
+        } else {
+          this.#handleCloseSelect();
+        }
         return;
 
       case 'Escape':
@@ -425,7 +455,7 @@ export class JhSelect extends JhInput {
         return;
 
       default:
-        this.#handleTypeAhead(e);
+        if (!this.searchable) this.#handleTypeAhead(e);
     }
   }
 
@@ -466,6 +496,40 @@ export class JhSelect extends JhInput {
     } else {
       this.#handleOpenSelect();
     }
+  }
+
+  #handleInputFocus(e) {
+    if (!this.searchable) return;
+    // Select all so the first keystroke replaces the current value
+    e.target.select();
+  }
+
+  #handleInputClick(e) {
+    if (!this.searchable) return;
+    // Prevent the wrapper click handler from toggling the menu closed
+    e.stopPropagation();
+    if (!this.#open) this.#handleOpenSelect();
+  }
+
+  #handleSearchInput(e) {
+    if (!this.searchable) return;
+    this.#searchTerm = e.target.value;
+    this.#applyFilter(this.#searchTerm);
+    // Highlight the first match so Enter can select it — surfaced, not committed
+    this.#activeIndex = null;
+    if (!this.#open) {
+      this.#handleOpenSelect();
+    }
+    if (this.#flatOptions.length) {
+      this.#setActiveItem(0);
+    }
+    this.requestUpdate();
+  }
+
+  #applyFilter(searchTerm) {
+    this.#flatOptions = searchTerm
+      ? JhFilter.filterList(this.#allOptions, searchTerm, 'label')
+      : this.#allOptions;
   }
 
   #handleSelection(index) {
@@ -599,9 +663,10 @@ export class JhSelect extends JhInput {
           <input
             role="combobox"
             type="text"
-            readonly
+            ?readonly=${this.readonly || !this.searchable}
             autocomplete="off"
             aria-haspopup="listbox"
+            aria-autocomplete=${ifDefined(this.searchable ? 'list' : undefined)}
             aria-controls="jh-select-listbox-${this.uniqueId}"
             id="jh-input-${this.uniqueId}"
             aria-expanded=${this.#open ? 'true' : 'false'}
@@ -615,46 +680,58 @@ export class JhSelect extends JhInput {
             aria-label=${ifDefined(this.accessibleLabel)}
             ?disabled=${this.disabled}
             ?required=${this.required}
-            .value=${this.#displayValue ?? ''} />
+            @focus=${this.#handleInputFocus}
+            @click=${this.#handleInputClick}
+            @input=${this.#handleSearchInput}
+            .value=${this.searchable && this.#searchTerm !== null
+              ? this.#searchTerm
+              : this.#displayValue ?? ''} />
           ${clearButton} ${rightSlot}
         </div>
       </div>
     `;
   }
 
-  renderData(options) {
-    if (!options) return null;
-    let flatIndex = 0;
+  #renderOption(option, idx) {
+    return html`<jh-list-item
+      role="option"
+      tabindex="-1"
+      ?disabled=${option.disabled}
+      ?selected=${String(this.value) === String(option.value)}
+      aria-selected=${String(this.value) === String(option.value)}
+      id="jh-select-option-${this.uniqueId}-${idx}"
+      class="${this.#activeIndex === idx ? 'is-active' : ''}"
+      primary-text=${option.label != null ? option.label : String(option.value)}></jh-list-item>`;
+  }
 
-    return options.map((option) => {
-      if (option.groupValues) {
-        const groupItems = option.groupValues.map((groupOption) => {
-          const idx = flatIndex++;
-          return html`<jh-list-item
-            role="option"
-            tabindex="-1"
-            ?disabled=${groupOption.disabled}
-            ?selected=${String(this.value) === String(groupOption.value)}
-            aria-selected=${String(this.value) === String(groupOption.value)}
-            id="jh-select-option-${this.uniqueId}-${idx}"
-            class="${this.#activeIndex === idx ? 'is-active' : ''}"
-            primary-text=${groupOption.label != null
-              ? groupOption.label
-              : String(groupOption.value)}></jh-list-item>`;
-        });
-        return html`<jh-list-group label=${option.groupLabel}>${groupItems}</jh-list-group>`;
+  #renderNoResults() {
+    // No tabindex keeps it inert (no hover/focus styles); role="status" announces the change
+    return html`<jh-list-item role="status">${this.noResultsText}</jh-list-item>`;
+  }
+
+  renderData(options) {
+    if (!options || !options.length) {
+      return this.searchable ? this.#renderNoResults() : null;
+    }
+
+    const content = [];
+    let index = 0;
+    while (index < options.length) {
+      const option = options[index];
+      if (option.groupLabel) {
+        const { groupLabel } = option;
+        const groupItems = [];
+        while (index < options.length && options[index].groupLabel === groupLabel) {
+          groupItems.push(this.#renderOption(options[index], index));
+          index += 1;
+        }
+        content.push(html`<jh-list-group label=${groupLabel}>${groupItems}</jh-list-group>`);
+      } else {
+        content.push(this.#renderOption(option, index));
+        index += 1;
       }
-      const idx = flatIndex++;
-      return html`<jh-list-item
-        role="option"
-        tabindex="-1"
-        ?disabled=${option.disabled}
-        ?selected=${String(this.value) === String(option.value)}
-        aria-selected=${String(this.value) === String(option.value)}
-        id="jh-select-option-${this.uniqueId}-${idx}"
-        class="${this.#activeIndex === idx ? 'is-active' : ''}"
-        primary-text=${option.label != null ? option.label : String(option.value)}></jh-list-item>`;
-    });
+    }
+    return content;
   }
 
   render() {
@@ -670,7 +747,7 @@ export class JhSelect extends JhInput {
               role="listbox"
               id="jh-select-listbox-${this.uniqueId}"
               @click=${this.#handleMenuClick}>
-              ${this.renderData(this.options)}
+              ${this.renderData(this.#flatOptions)}
             </jh-menu>
           </div>`
         : null}

--- a/packages/jh-elements/components/select/select.mdx
+++ b/packages/jh-elements/components/select/select.mdx
@@ -15,7 +15,8 @@ import * as stories from './select.stories.js';
 <hr />
 
 The select component is a form component that allows users to choose a single option from a predefined list. 
-It combines a specialized non-editable input field with a popover menu and supports flat options and grouped options.
+It combines a specialized input field with a popover menu and supports flat options and grouped options. 
+The select is non-editable by default and can be made searchable with the `searchable` attribute.
 
 ## Usage
 
@@ -84,6 +85,24 @@ const groupedOptions = [
 ];
 ```
 
+## Type-Ahead and Searchable behaviors
+
+### Type-Ahead
+
+In the non-editable select (default), typing character keys jumps to the first matching option. Pressing the same character repeatedly cycles through options that start with that character.
+The type-ahead buffer resets after 500 milliseconds, so if the user pauses while typing, the next character key will start a new search rather than continuing to cycle through the current character matches.
+
+### Searchable
+
+Set the `searchable` attribute to let users type in the input field to filter the list of options. 
+Filtering matches the option `label` (case-insensitive) and works across both flat and grouped options — groups with no matching options are hidden.
+
+- Opening the menu keeps the currently selected label in the field and selects the text, so the first keystroke replaces it.
+- Typing filters the list. The first match is highlighted so pressing `Enter` selects it, but no value is committed until an option is chosen.
+- Use the Arrow keys to move through the filtered options and `Enter` to make a selection. `Space` types a space character rather than selecting.
+- When no options match, a non-selectable "No results found" message is displayed. Customize this text with the `no-results-text` attribute.
+- Closing the menu without choosing an option reverts the field to the previously selected value.
+
 ## Setting the Value
 
 ### Initial value
@@ -134,13 +153,13 @@ This allows you to easily populate the menu with commonly used lists without hav
 
 - Additional datasets may be added in the future and can be requested by submitting a Github Issue.
 
-For more control over the datasets, authors may use the `manageDataset` util to customize initial selected values, disabled items, and empty labels:
+For more control over the datasets, authors may use the `manageSelectDataset` method to customize initial selected values, disabled items, and empty labels:
 
 ```javascript
 import { US_STATES_FLAT } from '@jack-henry/jh-datasets/datasets/us-states-flat.js';
-import { manageDataset } from '@jack-henry/jh-datasets/utils/manage-dataset.js';
+import { manageSelectDataset } from '@jack-henry/jh-datasets/utils/manageDataset.js';
 
-const customizedData = manageDataset({
+const customizedData = manageSelectDataset({
   dataset: US_STATES_FLAT,
   initialValue: null,
   disabledItems: ['AK', 'HI'],
@@ -149,11 +168,6 @@ const customizedData = manageDataset({
 
 <jh-select label="State" .options=${customizedData}></jh-select>
 ```
-
-## Type-Ahead functionality
-
-Typing character keys jumps to the first matching option. Pressing the same character repeatedly cycles through options that start with that character.
-The type-ahead buffer resets after 500 milliseconds, so if the user pauses while typing, the next character key will start a new search rather than continuing to cycle through the current character matches.
 
 ## Dependencies
 
@@ -192,7 +206,7 @@ The following success criteria are of concern:
 
 ### What we provide
 
-- To satisfy [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) and [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value), the select uses the `combobox` role with `aria-expanded`, `aria-haspopup`, `aria-controls`, and `aria-activedescendant` to communicate the relationship between the input and the listbox. Any `label`, `helper-text`, and `error-text` are associated with the input control by default.
+- To satisfy [WCAG 1.3.1 Info and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) and [WCAG 4.1.2 Name, Role, Value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value), the select uses the `combobox` role with `aria-expanded`, `aria-haspopup`, `aria-controls`, and `aria-activedescendant` to communicate the relationship between the input and the listbox. When `searchable` is set, the input also exposes `aria-autocomplete="list"` to indicate that typing filters the options without automatically selecting one. Any `label`, `helper-text`, and `error-text` are associated with the input control by default.
 - To satisfy [WCAG 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html), Select can be resized without assistive technology up to 200 percent without loss of content or functionality.
 - To satisfy [WCAG 1.4.11 Non-text Contrast](https://www.w3.org/WAI/WCAG22/Understanding/non-text-contrast.html) and [WCAG 2.4.7 Focus Visible](https://www.w3.org/WAI/WCAG22/Understanding/focus-visible.html), interactive elements include focus styles and the active option receives a visible highlight.
 - To satisfy [WCAG 2.1.1 Keyboard](https://www.w3.org/WAI/WCAG22/Understanding/keyboard.html), the select supports full keyboard navigation including arrow keys, Enter, Space, Escape, Tab, and type-ahead character matching.
@@ -209,7 +223,7 @@ The following success criteria are of concern:
 ### Keyboard Interaction
 
 - **Arrow Down / Arrow Up**: Opens the menu (when closed) or navigates through options (when open).
-- **Enter / Space**: Opens the menu (when closed) or selects the active option (when open).
+- **Enter / Space**: Opens the menu (when closed) or selects the active option (when open). In searchable mode, `Space` inserts a space character instead of selecting.
 - **Escape**: Closes the menu without selecting.
 - **Tab**: Closes the menu and moves focus to the next focusable element.
 

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -70,6 +70,8 @@ const disableControls = {
   size: { control: { disable: true } },
   value: { control: { disable: true } },
   'flip-disabled': { control: { disable: true } },
+  searchable: { control: { disable: true } },
+  'no-results-text': { control: { disable: true } },
 }
 
 function logCustomEvent(name, e) {
@@ -149,6 +151,14 @@ export default {
       description: 'Sets the value of the select programmatically.',
     },
     'flip-disabled': { control: 'boolean' },
+    searchable: {
+      control: 'boolean',
+      description: 'Allows users to type in the input field to filter the list of options.',
+    },
+    'no-results-text': {
+      control: 'text',
+      description: 'Sets the message shown in the menu when a search returns no matching options. Only applies when `searchable` is set.',
+    },
     // Hide inherited jh-input slots
     'jh-input-right': { table: { disable: true } },
     'jh-input-left': { table: { disable: true } },
@@ -213,6 +223,23 @@ Overview.argTypes = {
   ...disableControls,
 };
 
+export const Searchable = { render: (args) => html`
+  <div class="select-container">
+    <jh-select searchable label="Select a state" helper-text="Type to filter the options" .options=${US_STATES_FLAT}></jh-select>
+  </div>
+  <div class="select-container">
+    <jh-select searchable label="Select an account" helper-text="Search works across groups" .options=${testOptions} value="cc-travel"></jh-select>
+  </div>
+`};
+
+Searchable.argTypes = {
+  ...disableControls,
+};
+
+Searchable.parameters = {
+  styles: storyStyles,
+};
+
 export const Playground = { render: (args) => html`
   <div class="select-container">
   <jh-select
@@ -231,6 +258,8 @@ export const Playground = { render: (args) => html`
     ?show-indicator=${args['show-indicator']}
     size=${args.size}
     ?flip-disabled=${args['flip-disabled']}
+    ?searchable=${args.searchable}
+    no-results-text=${ifDefined(args['no-results-text'] === '' ? null : args['no-results-text'])}
     .options=${testOptions}
     value=${args.value}
   ></jh-select>
@@ -256,6 +285,8 @@ Playground.args = {
   'show-indicator': false,
   size: 'medium',
   'flip-disabled': false,
+  searchable: false,
+  'no-results-text': 'No results found',
   value: "",
 };
 

--- a/packages/jh-elements/components/select/select.stories.js
+++ b/packages/jh-elements/components/select/select.stories.js
@@ -173,6 +173,7 @@ export default {
     'inputmode': { table: { disable: true } },
     'maxlength': { table: { disable: true } },
     'minlength': { table: { disable: true } },
+    'pattern': { table: { disable: true } },
     'show-char-count': { table: { disable: true } },
     'show-clear-button': { table: { disable: true } },
     // Hide inherited jh-input events not relevant to select

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5897,6 +5897,18 @@
           "default": "false"
         },
         {
+          "name": "searchable",
+          "description": "Allows users to type in the input field to filter the list of options.",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "no-results-text",
+          "description": "Sets the message shown in the menu when a search returns no matching options. Only applies when `searchable` is set.",
+          "type": "string",
+          "default": "\"No results found\""
+        },
+        {
           "name": "accessible-label",
           "description": "Sets an `aria-label` on the input field to assist screen reader users when no visible label is present.",
           "type": "?string"
@@ -6047,6 +6059,20 @@
           "description": "Prevents the dropdown menu from automatically flipping its position when there is insufficient viewport space.",
           "type": "boolean",
           "default": "false"
+        },
+        {
+          "name": "searchable",
+          "attribute": "searchable",
+          "description": "Allows users to type in the input field to filter the list of options.",
+          "type": "boolean",
+          "default": "false"
+        },
+        {
+          "name": "noResultsText",
+          "attribute": "no-results-text",
+          "description": "Sets the message shown in the menu when a search returns no matching options. Only applies when `searchable` is set.",
+          "type": "string",
+          "default": "\"No results found\""
         },
         {
           "name": "accessibleLabel",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It adds the searchable select component (phase 2) and updates stories and docs accordingly.

**Idea number or other reference :** 28

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

_add any other details on how to test_ 

## Notes/Dependencies

I am going to put it in Draft review because there are still a few open questions to discuss with the team.