### PR TITLE
[Docs] Add generic and component specific Security sections

### DIFF
--- a/packages/jh-elements/components/button/button.mdx
+++ b/packages/jh-elements/components/button/button.mdx
@@ -65,6 +65,10 @@ Set a pending state to indicate a process is underway, such as saving a record o
 - When in a pending state, a button cannot be navigated to nor activated by a mouse or keyboard.
 - If the pending state of a button reflects the changing of a live-region, and the announcement of those changes should wait until completed, set `aria-busy=“true”` to the region until the process is complete. Once completed, set `aria-busy="false"`.
 
+## Security
+
+The value bound to `href` is rendered as-is and is not sanitized. When the URL originates from an untrusted source, validate it against an allowlist of expected schemes (e.g. `https:`) to avoid `javascript:` and other unsafe URLs. See [Security](/docs/getting-started-usage--docs#security) for system-wide guidance.
+
 ## Accessibility
 
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria. The following success criteria are of concern:

--- a/packages/jh-elements/components/tag/tag.mdx
+++ b/packages/jh-elements/components/tag/tag.mdx
@@ -58,6 +58,10 @@ The tag component makes use of both required compositional and suggested content
 
 - `<jh-icon>`. [Iconography documentation](/docs/iconography-overview--docs).
 
+## Security
+
+The value bound to `href` is rendered as-is and is not sanitized. When the URL originates from an untrusted source, validate it against an allowlist of expected schemes (e.g. `https:`) to avoid `javascript:` and other unsafe URLs. See [Security](/docs/getting-started-usage--docs#security) for system-wide guidance.
+
 ## Accessibility
 
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria. 

--- a/packages/jh-elements/components/toast-controller/toast-controller.mdx
+++ b/packages/jh-elements/components/toast-controller/toast-controller.mdx
@@ -73,6 +73,10 @@ Both the `bubbles` and `composed` properties should be set to `true` in order to
     e.target.dispatchEvent(createToast);
 ```
 
+## Security
+
+The `jh-create-toast` event detail values (such as `text`, `toastIcon`, `toastAction`, and `toastDismissIcon`) are rendered as HTML. When any of these values originate from an untrusted source, sanitize them before dispatching the event to avoid injecting unsafe HTML. See [Security](/docs/getting-started-usage--docs#security) for system-wide guidance.
+
 ## Accessibility
 
 This component satisfies [WCAG 2.2](https://www.w3.org/TR/WCAG22/) AA success criteria.

--- a/packages/jh-elements/docs/getting-started/usage.mdx
+++ b/packages/jh-elements/docs/getting-started/usage.mdx
@@ -151,6 +151,16 @@ JavaScript properties differ from content attributes which are always strings. A
 into a desired data type and store the transformed value. For example, an attribute may have a value of "24", while the associated
 property has an integer value of 24. Review each component doc to better understand the data type each attribute will be transformed to.
 
+### Security
+
+Our components render the content and values you provide as-is and do not sanitize author-supplied input. Any data that originates from an untrusted source (end users, external APIs, URL parameters, etc.) must be sanitized by you before it is passed to a component. This applies to:
+
+- **URLs**, such as values bound to `href`. Validate against an allowlist of expected schemes (e.g. `https:`) to avoid `javascript:` and other unsafe URLs.
+- **Slotted content**, which is injected into the light DOM unchanged. Treat any HTML you place in a slot as you would `innerHTML` and sanitize it if it contains untrusted data.
+- **Content passed through events**, such as the `jh-create-toast` event consumed by `jh-toast-controller`, which renders the provided strings as HTML.
+
+Prefer text bindings over raw HTML where possible, and use a vetted sanitizer (for example, DOMPurify) when untrusted HTML must be rendered.
+
 ### Slots
 
 Slots are a core feature of the web component technology suite, and allows authors to inject their own content into a component. Slotted content remains in the Light DOM, which means it is not encapsulated by the component's Shadow DOM. This behavior provides two key benefits:


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It addresses the vulnerability scan results about url and HTML sanitization:
- it adds a system-wide Security section that explains that it is the authors' responsibility to sanitize content (like URLs and HTML) inserted into the FDS components via slots, properties, or other means.
- it adds component specific Security sections for jh-tag (href property), jh-button (href property), jh-toast-controller (HTML injection).

**Vulnerability links**:
- https://github.com/Banno/jack-henry-design-system/security/code-scanning/5
- https://github.com/Banno/jack-henry-design-system/security/code-scanning/2
- https://github.com/Banno/jack-henry-design-system/security/code-scanning/3
 

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)