### PR TITLE
[jh-input-password] confine jh-select event and update docs

### DIFF
--- a/.changeset/sour-ravens-wish.md
+++ b/.changeset/sour-ravens-wish.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[input-password] it confines the jh-select event to the component itself.

--- a/packages/jh-elements/components/element/element.js
+++ b/packages/jh-elements/components/element/element.js
@@ -36,7 +36,9 @@ export class JhElement extends LitElement {
     return this.#internals;
   }
 
-  dispatchCustomEvent(eventName, detail = {}) {
+  dispatchCustomEvent(eventName, detail = {}, options = {}) {
+    const { bubbles = true, composed = true, cancelable = true } = options;
+
     // gather base detail info
     let baseDetail = {
       form: {
@@ -74,9 +76,9 @@ export class JhElement extends LitElement {
     // create and dispatch event
     const event = new CustomEvent(eventName, {
       detail: finalDetail,
-      bubbles: true,
-      composed: true,
-      cancelable: true,
+      bubbles,
+      composed,
+      cancelable,
     });
     this.dispatchEvent(event);
   }

--- a/packages/jh-elements/components/input-password/input-password.js
+++ b/packages/jh-elements/components/input-password/input-password.js
@@ -11,6 +11,7 @@ import '@jack-henry/jh-icons/icons-wc/icon-eye.js';
 /**
  * @slot jh-input-password-hidden - Use to insert a custom icon within the toggle password button when the input value is masked. 
  * @slot jh-input-password-visible - Use to insert a custom icon within the toggle password button when the input value is unmasked.
+ * @event jh-select - Dispatched when text is selected. Event payload contains the selected text, the starting index of the selection, and the ending index of the selection. These values can be accessed via `e.detail.state.selection`, `e.detail.state.selectionStart`, and `e.detail.state.selectionEnd`. Unlike other inputs, this event does not bubble or cross the shadow boundary, so it is only observable on the element itself.
  * @customElement jh-input-password
  */
 export class JhInputPassword extends JhInput {
@@ -159,6 +160,12 @@ export class JhInputPassword extends JhInput {
 
   #togglePassword() {
     this.passwordVisible = !this.passwordVisible;
+  }
+
+  // Keep jh-select (carries selected text) from leaving the component, matching native select which doesn't bubble.
+  dispatchCustomEvent(eventName, detail = {}, options = {}) {
+    const confined = eventName === 'jh-select' ? { bubbles: false, composed: false } : {};
+    super.dispatchCustomEvent(eventName, detail, { ...confined, ...options });
   }
 }
 JhInputPassword.register('jh-input-password', JhInputPassword);

--- a/packages/jh-elements/components/input-password/input-password.stories.js
+++ b/packages/jh-elements/components/input-password/input-password.stories.js
@@ -60,7 +60,6 @@ export default {
       (story) => html`
         <div class="story-decorator"
           @jh-change=${(e) => logCustomEvent('jh-change', e)}
-          @jh-select=${(e) => logCustomEvent('jh-select', e)}
           @jh-input=${(e) => logCustomEvent('jh-input', e)}
           @jh-maxlength=${(e) => logCustomEvent('jh-maxlength', e)}
           @jh-input:clear-button-click=${(e) => logCustomEvent('jh-input:clear-button-click', e)}
@@ -159,7 +158,7 @@ export default {
 };
 
 export const Overview = { render: (args) => html`
-  <jh-input-password label="Label" helper-text="Helper text" required show-indicator></jh-input-password>
+  <jh-input-password label="Label" helper-text="Helper text" required show-indicator @jh-select=${(e) => logCustomEvent('jh-select', e)}></jh-input-password>
 `};
 
 Overview.argTypes = {
@@ -168,7 +167,7 @@ Overview.argTypes = {
 
 export const Playground = {
   render: (args) => html`
-  <jh-input-password 
+  <jh-input-password @jh-select=${(e) => logCustomEvent('jh-select', e)}
     ?password-visible=${args['password-visible']} 
     accessible-label-show-password=${ifDefined(
       args['accessible-label-show-password'] === ''
@@ -286,7 +285,7 @@ Playground.parameters = {
 };
 
 export const Default = { render: (args) => html`
-  <jh-input-password></jh-input-password>
+  <jh-input-password @jh-select=${(e) => logCustomEvent('jh-select', e)}></jh-input-password>
 `};
 
 Default.argTypes = {

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -2743,7 +2743,7 @@
       "events": [
         {
           "name": "jh-select",
-          "description": "Dispatched when text is selected. Event payload contains the selected text, the starting index of the selection, and the ending index of the selection. These values can be accessed via `e.detail.state.selection`, `e.detail.state.selectionStart`, and `e.detail.state.selectionEnd`."
+          "description": "Dispatched when text is selected. Event payload contains the selected text, the starting index of the selection, and the ending index of the selection. These values can be accessed via `e.detail.state.selection`, `e.detail.state.selectionStart`, and `e.detail.state.selectionEnd`. Unlike other inputs, this event does not bubble or cross the shadow boundary, so it is only observable on the element itself."
         },
         {
           "name": "jh-change",


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It fixes a vulnerability where the `jh-select` event on `jh-input-password` was composed and bubbling. This means that the Event API payload was readable at the page level. With this change we are setting the `select` event to function in the same way as on the native HTML `<input type=password>` so that it is only accessible from the element itself.

- updated the `jh-element` base class to accept options for `composed`, `bubbles` and `cancelable`.
- updated `jh-input-password` to make the `jh-select` event not composed and non bubbling.
- updated the API table for `jh-input-password` to note that the event is only available directly on the element.

**Idea number or other reference : https://github.com/Banno/jack-henry-design-system/security/code-scanning/4

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

Check that the jh-select event is not captured in the 'Actions' tab on Storybook. The listeners in the stories are attached to a container div, so the `jh-select` event should not be visible any more.