### PR TITLE
[Icons] fix icon template issues and regenerate icons

### DIFF
--- a/.changeset/lazy-needles-obey.md
+++ b/.changeset/lazy-needles-obey.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-icons": patch
+---
+
+[icons] updates icon generation script and corrects robot-sparkles icon class name.

--- a/packages/jh-icons/_templates/icon/new/icon.ejs.t
+++ b/packages/jh-icons/_templates/icon/new/icon.ejs.t
@@ -94,7 +94,7 @@ export default class <%= h.inflection.camelize(prefix.replace(/-/gi,'_')) %>Icon
 
   render() {
     return html`
-      <%- svg %>
+      <%- svg.replace(/\\/g, '\\\\').replace(/`/g, '\\`').replace(/\$\{/g, '\\${') %>
     `;
   }
 }

--- a/packages/jh-icons/bin/generate-wc.js
+++ b/packages/jh-icons/bin/generate-wc.js
@@ -2,7 +2,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0
 
-const { exec } = require('child_process');
+const { execFile } = require('child_process');
 
 const args = process.argv.slice(2); // args[0] = sourcePath, args[1] = outputPath, args[2] = prefix
 
@@ -37,12 +37,29 @@ const icons = iconFiles
     };
   });
  
-  // For each icon, call exec create the component using hygen generator
-  icons.forEach(async icon => {
-  try {
-    await exec(`hygen icon new ${icon.name} --svg '${icon.contents}' --outputPath ${args[1]} --prefix ${args[2]}`);
-    console.log(`${icon.name} created`)
-  } catch (e) {
-    console.error('error generating icon:', e);
-  }
+  // For each icon, call the hygen generator to create the component.
+  // Use execFile with an argument array (no shell) so SVG content cannot
+  // break out of the command and inject shell syntax.
+  icons.forEach(icon => {
+  execFile(
+    'hygen',
+    [
+      'icon',
+      'new',
+      icon.name,
+      '--svg',
+      icon.contents,
+      '--outputPath',
+      args[1],
+      '--prefix',
+      args[2],
+    ],
+    error => {
+      if (error) {
+        console.error('error generating icon:', error);
+        return;
+      }
+      console.log(`${icon.name} created`);
+    }
+  );
 });

--- a/packages/jh-icons/icons-wc/icon-robot-sparkles.js
+++ b/packages/jh-icons/icons-wc/icon-robot-sparkles.js
@@ -5,7 +5,7 @@
 */
 import {LitElement, css, html} from 'lit';
 
-export default class JhIconRobotSparkle extends LitElement {
+export default class JhIconRobotSparkles extends LitElement {
   /** @type {ElementInternals} */
   #internals;
 
@@ -91,4 +91,4 @@ export default class JhIconRobotSparkle extends LitElement {
   }
 }
 
-customElements.define('jh-icon-robot-sparkles', JhIconRobotSparkle);
+customElements.define('jh-icon-robot-sparkles', JhIconRobotSparkles);


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It fixes 2 vulnerabilities present in our icons generator:
- Command injection (`generate-wc.js`): SVG content was interpolated into a shell string passed to exec, so a `'` in an SVG could break out and run arbitrary shell commands. Fixed by using `execFile` with an argument array.
- Template literal injection (`icon.ejs.t`): raw SVG was embedded into a html`...` literal via `<%- svg %>`, so a backtick or `${...}` in an SVG could break out and inject JS into the generated file. Fixed by escaping ``, ${, and \`.

In addition, by regenerating the icons, it fixes a bug in the `robot-sparkles` icon, which had been generated when we still had the "classify" bug in our generator.

**Idea number or other reference :** 
https://github.com/Banno/jack-henry-design-system/security/code-scanning/7
https://github.com/Banno/jack-henry-design-system/security/code-scanning/8

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [X] Review icons
- [X] Run script(s)
- [ ] Other (add details below)

**Additional Details**

1. run the `pnpm build:jh-icons` script to check that WC icons are generated correctly.
2. Add an svg icon that violates the rules above and regenerate the wc-icons. The icons should be generated correctly.  
3. Inspect the icon in question and see how the special characters are handled.

To execute step 2, cd into `jh-icons` and run the following:

```
cat > icons-svg/pwn-test.svg <<'EOF'
<svg viewBox="0 0 24 24"><path d="M1 1'; touch /tmp/HACKED #"/><path d="${process.exit(1)}`;globalThis.x=1;html`"/></svg>
EOF

pnpm run build-wc
```

