### PR TITLE
[Toast Controller] Removes reference to deprecated appearance property

### DIFF
--- a/packages/jh-elements/components/toast-controller/toast-controller.js
+++ b/packages/jh-elements/components/toast-controller/toast-controller.js
@@ -87,7 +87,6 @@ export class JhToastController extends JhElement {
       text,
       toastIcon,
       dismissButtonAccessibleLabel,
-      appearance,
       hideDismissButton,
       timeout,
       stacked,
@@ -98,7 +97,6 @@ export class JhToastController extends JhElement {
     text ? toast.innerHTML += text : null;
     toastIcon ? toast.innerHTML += toastIcon : null;
     dismissButtonAccessibleLabel ? toast.setAttribute('dismiss-button-accessible-label', dismissButtonAccessibleLabel) : null;
-    appearance ? toast.setAttribute('appearance', appearance) : null;
     hideDismissButton ? toast.setAttribute('hide-dismiss-button', '') : null;
     timeout >= 0 ? toast.setAttribute('timeout', timeout) : null;
     stacked ? toast.setAttribute('stacked', '') : null;

--- a/packages/jh-elements/components/toast-controller/toast-controller.mdx
+++ b/packages/jh-elements/components/toast-controller/toast-controller.mdx
@@ -56,7 +56,6 @@ Both the `bubbles` and `composed` properties should be set to `true` in order to
 ```html
    const createToast = new CustomEvent('jh-create-toast', {
       detail: {
-        appearance: 'positive',
         stacked: false,
         text: 'Toast',
         timeout: 0,

--- a/packages/jh-elements/components/toast-controller/toast-controller.stories.js
+++ b/packages/jh-elements/components/toast-controller/toast-controller.stories.js
@@ -57,9 +57,9 @@ export const Overview = {
   render: (args) => html`
     <div class="overview-story">
       <jh-toast-controller>
-        <jh-toast timeout=0 appearance="positive" hide-dismiss-button>Address successfully updated.<jh-icon-circle-info slot="jh-toast-icon"></jh-icon-circle-info></jh-toast>
-        <jh-toast timeout=0 appearance="neutral" dismiss-button-accessible-label="dismiss toast">Email deleted.<jh-button slot="jh-toast-action" label="Undo"></jh-button></jh-toast>
-        <jh-toast timeout=0 appearance="negative" dismiss-button-accessible-label="dismiss toast">Failed to send email.</jh-toast>
+        <jh-toast timeout=0 hide-dismiss-button>Address successfully updated.<jh-icon-circle-info slot="jh-toast-icon"></jh-icon-circle-info></jh-toast>
+        <jh-toast timeout=0 dismiss-button-accessible-label="dismiss toast">Email deleted.<jh-button slot="jh-toast-action" label="Undo"></jh-button></jh-toast>
+        <jh-toast timeout=0 dismiss-button-accessible-label="dismiss toast">Failed to send email.</jh-toast>
       </jh-toast-controller>
     </div>
   `,
@@ -83,7 +83,6 @@ const createToast = (storyId) => {
   }
 
   let toast = document.createElement('jh-toast');
-  toast.setAttribute('appearance', 'positive');
   toast.setAttribute('dismiss-button-accessible-label', 'dismiss toast');
   toast.setAttribute('timeout', '0');
   toast.innerHTML = `Toast added! Enable screen reader to test addition of toast to the controller.`;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

Removes references to the deprecated `toast` component `appearance` property. 

**Idea number or other reference :** n/a

## How To Test

Select all that apply:

- [ ] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**
n/a

## Notes/Dependencies
n/a


