### PR TITLE
[Menu] Add overflow styling hooks and update docs

### DIFF
--- a/.changeset/kind-apes-fry.md
+++ b/.changeset/kind-apes-fry.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[Menu] adds overflow styling hooks and updates docs

--- a/packages/jh-elements/components/menu/menu.js
+++ b/packages/jh-elements/components/menu/menu.js
@@ -12,6 +12,8 @@ import { JhElement } from '../element/element.js';
  * @cssprop --jh-menu-border-radius - The menu border-radius. Defaults to `--jh-border-radius-200`.
  * @cssprop --jh-menu-space-padding - The menu container padding. Defaults to `--jh-dimension-200 0`.
  * @cssprop --jh-menu-color-text - The text color. Defaults to `--jh-color-content-primary-enabled`.
+ * @cssprop --jh-menu-overflow - The menu host overflow, which controls clipping of the menu (including its rounded corners). Defaults to `hidden`.
+ * @cssprop --jh-menu-content-overflow - The menu content overflow, which controls scrolling of the menu items. Defaults to `hidden auto`.
  *
  * @slot default - Use to insert menu items.
  * @customElement jh-menu
@@ -43,12 +45,12 @@ export class JhMenu extends JhElement {
         display: flex;
         flex-direction: column;
         position: relative;
-        overflow: hidden;
+        overflow: var(--jh-menu-overflow, hidden);
         height: 100%;
       }
       .menu-content {
         flex: 1;
-        overflow-y: auto;
+        overflow: var(--jh-menu-content-overflow, hidden auto);
         width: 100%;
       }
     `;

--- a/packages/jh-elements/components/menu/menu.mdx
+++ b/packages/jh-elements/components/menu/menu.mdx
@@ -15,7 +15,7 @@ import * as stories from './menu.stories.js';
 
 <hr />
 
-Menus display lists of choices or actions. This is not a Navigation component.
+Menus provides a styled, elevated surface for menus and dropdown-style content. It works as a list of choices or actions, or as a general container for related content. This is not a Navigation component.
 
 ## Usage
 
@@ -25,7 +25,7 @@ Import the `<jh-menu>` component:
 import '@jack-henry/jh-elements/components/menu/menu.js';
 ```
 
-To use `<jh-menu>`, add menu items, such as `<jh-list-item>`s to the default slot.
+To use `<jh-menu>`, add items, such as `<jh-list-item>` components to the default slot.
 
 ```html
 <jh-menu>
@@ -60,19 +60,20 @@ is available to user agents, including assistive technologies.
 
 - To satisfy [WCAG 1.3.1 Information and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) 
 and [WCAG 4.1.2 Name, role, value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html),
-the `<jh-menu>` component has a `role` of `menu`. Authors may override this role if required.
+the `<jh-menu>` component has a default role of `menu`, which is appropriate when it contains a set of menu items. 
+When using `<jh-menu>` as a general container for other content (for example, form controls), authors should override the role to one that matches the content, or remove it, so the exposed semantics are accurate.
 - To satisfy [WCAG 1.4.4 Resize Text](https://www.w3.org/WAI/WCAG22/Understanding/resize-text.html), Menu can be resized without assistive technology up to 200 percent without loss of content or functionality.
 
 
 ### Author Guidance
 
-- To satisfy [WCAG 1.3.1 Information and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) 
-and [WCAG 4.1.2 Name, role, value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html),
- authors should assign appropriate roles to the items in the default slot. Possible roles include:
+- When using `<jh-menu>` as a menu, authors should assign appropriate roles to the items in the default slot to satisfy [WCAG 1.3.1 Information and Relationships](https://www.w3.org/WAI/WCAG22/Understanding/info-and-relationships.html) 
+and [WCAG 4.1.2 Name, role, value](https://www.w3.org/WAI/WCAG22/Understanding/name-role-value.html). Possible roles include:
   - `menuitem`: used to indicate the element is an option in a set of choices contained by a menu.
   - `menuitemcheckbox`: used to indicate a menuitem with a checkable state whose possible values are true, false, or mixed.
   - `menuitemradio`: used to indicate a menuitem with a checkable state in a set of elements with the same role, only one of which can be checked at a time. 
-- Where required, authors are responsible for assigning tabindex, and handling different scenarios of keyboard navigation.
+- When using `<jh-menu>` as a general container rather than a menu, override or remove the default `role="menu"` so it does not expose menu semantics to assistive technologies, and apply roles/labels appropriate to the content you place inside.
+- Authors are responsible for assigning `tabindex` and handling keyboard navigation appropriate to their content and use case.
 
 ## Component API
 

--- a/packages/jh-elements/components/menu/menu.stories.js
+++ b/packages/jh-elements/components/menu/menu.stories.js
@@ -6,6 +6,7 @@ import { html, css } from 'lit';
 import './menu.js';
 import '../list-item/list-item.js';
 import '../list-group/list-group.js';
+import '../select/select.js';
 import '@jack-henry/jh-icons/icons-wc/icon-printer';
 import '@jack-henry/jh-icons/icons-wc/icon-arrow-down-to-bracket';
 import '@jack-henry/jh-icons/icons-wc/icon-pencil';
@@ -102,4 +103,32 @@ Playground.parameters = {
   controls: { hideNoControlsWarning: true },
   styles: storyStyles,
   theme: 'both-themes',
+};
+
+// TEMP: showcases a jh-select inside a jh-menu escaping the menu bounds via the overflow hooks.
+const selectOptions = [
+  { label: 'Checking', value: 'checking' },
+  { label: 'Savings', value: 'savings' },
+  { label: 'Money Market', value: 'money-market' },
+  { label: 'Certificate of Deposit', value: 'cd' },
+];
+
+export const SelectPopout = {
+  render: (args) => html`
+  <div class="menu-wrapper">
+    <jh-menu
+      style="--jh-menu-overflow: visible; --jh-menu-content-overflow: visible;"
+    >
+      <jh-list-item tabindex="0" role="menuitem">Item number 1</jh-list-item>
+      <jh-list-item>
+      <jh-select label="Select an account" .options=${selectOptions}></jh-select>
+    </jh-list-item>
+    </jh-menu>
+  </div>
+  `,
+};
+
+SelectPopout.parameters = {
+  controls: { hideNoControlsWarning: true },
+  styles: storyStyles,
 };

--- a/packages/jh-elements/custom-elements.json
+++ b/packages/jh-elements/custom-elements.json
@@ -5662,6 +5662,14 @@
         {
           "name": "--jh-menu-color-text",
           "description": "The text color. Defaults to `--jh-color-content-primary-enabled`."
+        },
+        {
+          "name": "--jh-menu-overflow",
+          "description": "The menu host overflow, which controls clipping of the menu (including its rounded corners). Defaults to `hidden`."
+        },
+        {
+          "name": "--jh-menu-content-overflow",
+          "description": "The menu content overflow, which controls scrolling of the menu items. Defaults to `hidden auto`."
         }
       ]
     },


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

- It fixes an issue where the overflow of the menu host and the menu content were locked, so different overflow options could not be achieved. We now provide 2 styling hooks, one to control clipping of the host and the other to control scrolling of the menu content. 
- It also updates the docs to provide guidance for when the menu is used as a dropdown or generic container rather than a menu containing list items.

**Idea number or other reference :** Bugfix

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [X] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

_add any other details on how to test_ 

## Notes/Dependencies

There is a temp story to show the overrides. It needs to be removed before merging.


