### PR TITLE
[Select] update menu display logic

### DIFF
--- a/.changeset/public-kings-nail.md
+++ b/.changeset/public-kings-nail.md
@@ -1,0 +1,5 @@
+---
+"@jack-henry/jh-elements": minor
+---
+
+[Select] corrects the menu hiding logic and updates menu-flipping method

--- a/packages/jh-elements/components/select/select.js
+++ b/packages/jh-elements/components/select/select.js
@@ -141,13 +141,11 @@ export class JhSelect extends JhInput {
           box-sizing: border-box;
           overflow: visible;
           position: absolute;
-          visibility: hidden;
-          opacity: 0;
+          display: none;
           width: 100%;
         }
         .menu-container.show {
-          visibility: visible;
-          opacity: 1;
+          display: block;
         }
         input::selection {
           background-color: transparent;
@@ -319,12 +317,19 @@ export class JhSelect extends JhInput {
     }
   }
 
-  #handleOpenSelect({ keyboard = false } = {}) {
+  async #handleOpenSelect({ keyboard = false } = {}) {
     if (this.disabled || this.readonly || !this.#flatOptions.length) return;
     if (!this.#inputWrapper || !this.#menuContainer) return;
 
-    this.#flipMenu();
+    // Render the menu first so it's laid out (display: none can't be measured),
+    // then measure/position it before the browser paints to avoid a flash.
     this.#open = true;
+    this.requestUpdate();
+    await this.updateComplete;
+    // Return if a user triggers a "close" while awaiting the render.
+    if (!this.#open) return;
+    this.#flipMenu();
+
     document.addEventListener('click', this.#boundDocumentClick, true);
     // Delay adding scroll listener so the menu's own layout change doesn't trigger it
     requestAnimationFrame(() => {
@@ -336,7 +341,6 @@ export class JhSelect extends JhInput {
         (opt) => String(opt.value) === String(this.value));
       this.#setActiveItem(selectedIdx !== -1 ? selectedIdx : 0);
     }
-    this.requestUpdate();
   }
   #handleCloseSelect() {
     this.#open = false;


### PR DESCRIPTION
<!--
SPDX-FileCopyrightText: 2026 Jack Henry

SPDX-License-Identifier: Apache-2.0
-->

## What It Does

It updates the menu display logic so that the jh-menu in select does not take up space on the page when it is closed.
It also updates the menu-flipping logic to await that the menu is open before flipping it. 

**Idea number or other reference :** Bug report

## How To Test

Select all that apply:

- [X] Review component(s) on Storybook
- [ ] Review documentation
- [ ] Review tokens
- [ ] Review icons
- [ ] Run script(s): _add scripts here_
- [ ] Other (add details below)

**Additional Details**

The difference is subtle. Use the Devtools to inspect the height of the menu container when closed. In addition, in the datasets story, there was a scrollbar in the Storybook Iframe even though nothing was visible that would require it. That is gone now. Compare with our main Storybook to see the difference.
